### PR TITLE
Update the power9 server as ppc64le.rubyci.org.

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -74,5 +74,5 @@ riscv.rubyci.org:
 graviton2.rubyci.org:
   <<: *default
 
-140.211.168.162: # power9
+ppc64le.rubyci.org: # power9
   <<: *default


### PR DESCRIPTION
I updated the `hosts.yml` file, as the power9 server has the domain now, 

I tested it by the following dryrun command.

```
$ bin/hocho apply -n ppc64le.rubyci.org
```
