### PR TITLE
Add arm64-neoverse-n1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ bin/hocho apply debian.rubyci.org
 
 ```bash
 # dry-run
-for i in debian10 funtoo amazon amazon2 opensuseleap arch icc freebsd12 fedora31 fedora32 centos7 debian9 debian openbsd ubuntu1804 ubuntu2004 ubuntu riscv graviton2 ppc64le s390x arm64-neoverse-n1; do bundle exec hocho apply -n "${i}.rubyci.org"; done
+for i in debian10 funtoo amazon amazon2 opensuseleap arch icc freebsd12 fedora31 fedora32 centos7 debian9 debian openbsd ubuntu1804 ubuntu2004 ubuntu riscv graviton2 arm64-neoverse-n1 ppc64le s390x; do bundle exec hocho apply -n "${i}.rubyci.org"; done
 
 # apply
-for i in debian10 funtoo amazon amazon2 opensuseleap arch icc freebsd12 fedora31 fedora32 centos7 debian9 debian openbsd ubuntu1804 ubuntu2004 ubuntu riscv graviton2 ppc64le s390x arm64-neoverse-n1; do bundle exec hocho apply "${i}.rubyci.org"; done
+for i in debian10 funtoo amazon amazon2 opensuseleap arch icc freebsd12 fedora31 fedora32 centos7 debian9 debian openbsd ubuntu1804 ubuntu2004 ubuntu riscv graviton2 arm64-neoverse-n1 ppc64le s390x; do bundle exec hocho apply "${i}.rubyci.org"; done
 ```
 
 ## TODO for chkbuild user

--- a/hocho.yml
+++ b/hocho.yml
@@ -55,11 +55,31 @@ driver_options:
           ;;
       esac
 
-      # TODO: support .tar.gz in mitamae-build
-      if [[ $mitamae_repo == "itamae-kitchen/mitamae-build" ]]; then
-        curl -fL "https://github.com/${mitamae_repo}/releases/latest/download/mitamae-${mitamae_arch}-${mitamae_os}" > "./mitamae-${mitamae_arch}-${mitamae_os}"
-      else
-        curl -fL "https://github.com/${mitamae_repo}/releases/latest/download/mitamae-${mitamae_arch}-${mitamae_os}.tar.gz" | tar xvz
-      fi
+      function url_exists {
+        local url="${1}"
+        curl -o /dev/null -sIf "$url"
+      }
+
+      # Get tags in new order.
+      tags=$(git ls-remote --refs --tags "https://github.com/${mitamae_repo}" \
+        | cut -d '/' -f 3 | sort -Vr)
+      for tag in ${tags}; do
+        url="https://github.com/${mitamae_repo}/releases/download/${tag}/mitamae-${mitamae_arch}-${mitamae_os}"
+        # TODO: support .tar.gz in mitamae-build
+        if [[ $mitamae_repo == "itamae-kitchen/mitamae-build" ]]; then
+          # If the URL exists, download it.
+          if ! url_exists "${url}"; then
+            continue
+          fi
+          curl -fL "${url}" > "./mitamae-${mitamae_arch}-${mitamae_os}"
+        else
+          url="${url}.tar.gz"
+          if ! url_exists "${url}"; then
+            continue
+          fi
+          curl -fL "${url}" | tar xvz
+        fi
+      done
+
       mv "mitamae-${mitamae_arch}-${mitamae_os}" /usr/local/bin/mitamae
       chmod +x /usr/local/bin/mitamae

--- a/hosts.yml
+++ b/hosts.yml
@@ -74,6 +74,9 @@ riscv.rubyci.org:
 graviton2.rubyci.org:
   <<: *default
 
+arm64-neoverse-n1.rubyci.org: # neoverse n1
+  <<: *default
+
 ppc64le.rubyci.org: # power9
   <<: *default
 


### PR DESCRIPTION
This PR includes the following things and fixes #17.

* A logic to add arm64-neoverse-n1 server.
* A new feature to get a newest "existing" mitamae-build released file from the releases.

After provisioning the commands written in the `README.md`, I will remove "WIP:" in the PR title.

## Note

The following command it to get tags in new order from mitamae-build repo. You can see [this URL](https://stackoverflow.com/questions/10649814/get-last-git-tag-from-a-remote-repo-without-cloning) for detail.

```
$ git ls-remote --refs --tags https://github.com/itamae-kitchen/mitamae-build \
    | cut -d '/' -f 3 | sort -Vr
v1.12.6
v1.12.4
v1.11.0
```

The command sorts considering the version format by the `sort -V` option like this.

```
$ git ls-remote --refs --tags https://github.com/rubygems/rubygems \
    | cut -d '/' -f 3 | sort -Vr
...
v3.2.11
v3.2.10
v3.2.9
...
```


The following command is to check if a URL exists or now. You can see [this URL](https://stackoverflow.com/questions/12199059/how-to-check-if-an-url-exists-with-the-shell-and-probably-curl) for detail.

```
$ curl -o /dev/null -sIf https://github.com/itamae-kitchen/mitamae-build/releases/download/v1.12.4/mitamae-s390x-linux

$ echo $?
0

$ curl -o /dev/null -sIf https://github.com/itamae-kitchen/mitamae-build/releases/download/v1.12.6/mitamae-s390x-linux

$ echo $?
22
```
