### PR TITLE
Synchronize host list in README with hosts.yml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ bin/hocho apply debian.rubyci.org
 
 ```bash
 # dry-run
-for i in debian10 funtoo amazon amazon2 opensuseleap arch icc freebsd12 fedora31 fedora32 centos7 debian9 debian openbsd ubuntu1804 ubuntu2004 ubuntu riscv graviton2 arm64-neoverse-n1 ppc64le s390x; do bundle exec hocho apply -n "${i}.rubyci.org"; done
+for i in $(bin/hosts); do bundle exec hocho apply -n "${i}"; done
 
 # apply
-for i in debian10 funtoo amazon amazon2 opensuseleap arch icc freebsd12 fedora31 fedora32 centos7 debian9 debian openbsd ubuntu1804 ubuntu2004 ubuntu riscv graviton2 arm64-neoverse-n1 ppc64le s390x; do bundle exec hocho apply "${i}.rubyci.org"; done
+for i in $(bin/hosts); do bundle exec hocho apply "${i}"; done
 ```
 
 ## TODO for chkbuild user

--- a/bin/hosts
+++ b/bin/hosts
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Show a host list in `hosts.yml`.
+
+require 'yaml'
+
+# FIXME: rubocop C: [Correctable] Security/YAMLLoad: Prefer using
+# YAML.safe_load over YAML.load.
+hosts = YAML.load(File.read('hosts.yml'))
+hosts.each_key do |host|
+  puts host
+end

--- a/hosts.yml
+++ b/hosts.yml
@@ -32,13 +32,7 @@ fedora31.rubyci.org:
 fedora32.rubyci.org:
   <<: *default
 
-centos6.rubyci.org:
-  <<: *default
-
 centos7.rubyci.org:
-  <<: *default
-
-centos8.rubyci.org:
   <<: *default
 
 rhel8.rubyci.org:
@@ -54,9 +48,6 @@ debian.rubyci.org:
   <<: *default
 
 openbsd.rubyci.org:
-  <<: *default
-
-ubuntu1604.rubyci.org:
   <<: *default
 
 ubuntu1804.rubyci.org:


### PR DESCRIPTION
This PR fixes #19.

I updated the `hosts.yml`, removing centos6, centos8, ubuntu1604. The hosts have already been removed in README at the commit 867ed345ccc3e68708bc6ebba9a95f84fac30a6f .

I checked the login availability by the following command.

```
$ for i in $(bin/hosts); do bash -cx "ssh "${i}" echo OK"; done
+ ssh debian10.rubyci.org echo OK
OK
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+ ssh funtoo.rubyci.org echo OK
OK
+ ssh amazon.rubyci.org echo OK
OK
+ ssh amazon2.rubyci.org echo OK
OK
+ ssh opensuseleap.rubyci.org echo OK
OK
+ ssh arch.rubyci.org echo OK
jaruga@arch.rubyci.org: Permission denied (publickey).
+ ssh icc.rubyci.org echo OK
OK
+ ssh freebsd12.rubyci.org echo OK
OK
+ ssh fedora31.rubyci.org echo OK
OK
+ ssh fedora32.rubyci.org echo OK
OK
+ ssh centos7.rubyci.org echo OK
OK
+ ssh rhel8.rubyci.org echo OK
OK
+ ssh debian9.rubyci.org echo OK
OK
+ ssh debian.rubyci.org echo OK
OK
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+ ssh openbsd.rubyci.org echo OK
OK
+ ssh ubuntu1804.rubyci.org echo OK
OK
+ ssh ubuntu2004.rubyci.org echo OK
OK
+ ssh ubuntu.rubyci.org echo OK
OK
+ ssh riscv.rubyci.org echo OK
OK
+ ssh graviton2.rubyci.org echo OK
OK
+ ssh arm64-neoverse-n1.rubyci.org echo OK
OK
+ ssh ppc64le.rubyci.org echo OK
/usr/bin/uname
OK
+ ssh s390x.rubyci.org echo OK
OK
```

Then I provisioned the hosts except arch.rubyci.org, as I can not login to the host arch.rubyci.org.

```
$ for i in $(bin/hosts | grep -v ^arch); do bundle exec hocho apply -n "${i}"; done

$ for i in $(bin/hosts | grep -v ^arch); do bundle exec hocho apply "${i}"; done
```
