### PR TITLE
Add commands to check if you can login to README.md. [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ sudo eix-update # to be automated too
 The specified domain is equivalent with the `Host <ip address>` in the `~/.ssh/config`.
 
 ```bash
+# check if you can login
+bash -cx "ssh debian.rubyci.org echo OK"
+
 # dry-run
 bin/hocho apply -n debian.rubyci.org
 
@@ -48,6 +51,9 @@ bin/hocho apply debian.rubyci.org
 ### All chkbuild
 
 ```bash
+# check if you can login
+for i in $(bin/hosts); do bash -cx "ssh ${i} echo OK"; done
+
 # dry-run
 for i in $(bin/hosts); do bundle exec hocho apply -n "${i}"; done
 


### PR DESCRIPTION
I executed the commands to check if I can login by SSH on #20 . As the commands are convenient to check it, I want to add the commands to `README.md`.

```
for i in $(bin/hosts); do bash -cx "ssh ${i} echo OK"; done
```

What do you think?
