### PR TITLE
Update recipe for opensuseleap

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,6 @@ include_recipe 'rbenv::user'
 file "/home/chkbuild/.bash_profile" do
   action :create
   owner 'chkbuild'
-  group 'chkbuild'
   mode '644'
   content <<-EOF
 export PATH="$HOME/.rbenv/bin:$PATH"


### PR DESCRIPTION
@junaruga I found the regression with https://github.com/ruby/ruby-infra-recipe/commit/fd7eaa21ff3d15e6a20fd26cc60077753124d7fd. 

When I applied recipe of the current master, hocho pulled too old version of `mitamae`.

```
[centos@ip-172-31-13-231 ~]$ mitamae version
MItamae v0.4.0
```

I think we should reverse the list of versions for mitamae.