### PR TITLE
Fix an old tag version's mitamae used.

### DIFF
--- a/hocho.yml
+++ b/hocho.yml
@@ -60,7 +60,7 @@ driver_options:
         curl -o /dev/null -sIf "$url"
       }
 
-      # Get tags in new order.
+      # Get tags in new order. The newest tag is first, the oldest tag is last.
       tags=$(git ls-remote --refs --tags "https://github.com/${mitamae_repo}" \
         | cut -d '/' -f 3 | sort -Vr)
       for tag in ${tags}; do
@@ -68,18 +68,21 @@ driver_options:
         # TODO: support .tar.gz in mitamae-build
         if [[ $mitamae_repo == "itamae-kitchen/mitamae-build" ]]; then
           # If the URL exists, download it.
-          if ! url_exists "${url}"; then
-            continue
+          if url_exists "${url}"; then
+            curl -fL "${url}" > "./mitamae-${mitamae_arch}-${mitamae_os}"
+            echo "mitamae '${tag}' is downloaded"
+            break
           fi
-          curl -fL "${url}" > "./mitamae-${mitamae_arch}-${mitamae_os}"
         else
           url="${url}.tar.gz"
-          if ! url_exists "${url}"; then
-            continue
+          if url_exists "${url}"; then
+            curl -fL "${url}" | tar xvz
+            echo "mitamae '${tag}' is downloaded"
+            break
           fi
-          curl -fL "${url}" | tar xvz
         fi
       done
 
       mv "mitamae-${mitamae_arch}-${mitamae_os}" /usr/local/bin/mitamae
       chmod +x /usr/local/bin/mitamae
+      /usr/local/bin/mitamae version


### PR DESCRIPTION
This PR fixes the issue detected at #23 .

The cause is that downloading mitamae by curl could be executed unintentionally multiple times, and the last downloaded mitamae was used. So, I added the break condition.

I tested, getting the newest available `mitamae` by removing the `/usr/local/bin/mitamae` file to trigger the logic to install the `mitamae`.

Here are the steps to test.

On fedora32 server.

```
[jaruga@fedora32 bin]$ sudo rm /usr/local/bin/mitamae
```

Then execute the command.

```
$ bin/hocho apply -n fedora32.rubyci.org
=> Running on fedora32.rubyci.org using mitamae
=> $ rsync -a --copy-links --copy-unsafe-links --delete --exclude\=.git --rsh ssh\ -o\ \"PubkeyAuthentication\=yes\"\ -o\ \"PasswordAuthentication\=yes\"\ -o\ \"PreferredAuthentications\=none,publickey,password,keyboard-interactive\"\ -o\ \"User\=jaruga\"\ -o\ \"IdentityFile\=\~/.ssh/ruby\" . fedora32.rubyci.org:/tmp/hocho-run-z0EJRnvPY/itamae
$ test -x /usr/local/bin/mitamae
=> fedora32.rubyci.org #                          mitamae_repo="itamae-kitchen/mitamae"
                         case "$(uname -s)" in
                           Linux)
                             mitamae_os="linux"
                             ;;
                           Darwin)
                             mitamae_os="darwin"
                             ;;
                           FreeBSD)
                             mitamae_os="freebsd"
                             mitamae_repo="itamae-kitchen/mitamae-build"
                             ;;
                           OpenBSD)
                             mitamae_os="openbsd"
                             mitamae_repo="itamae-kitchen/mitamae-build"
                             ;;
                           SunOS)
                             mitamae_os="solaris" # should be "sunos"?
                             mitamae_repo="itamae-kitchen/mitamae-build"
                             ;;
                           *)
                             echo "OS '$(uname -s)' is not supported yet"
                             exit 1
                             ;;
                         esac
                         
                         case "$(uname -m)" in
                           x86_64)
                             mitamae_arch="x86_64"
                             ;;
                           aarch64)
                             mitamae_arch="aarch64"
                             ;;
                           ppc64le)
                             mitamae_arch="ppc64le"
                             mitamae_repo="itamae-kitchen/mitamae-build"
                             ;;
                           s390x)
                             mitamae_arch="s390x"
                             mitamae_repo="itamae-kitchen/mitamae-build"
                             ;;
                           *)
                             echo "machine '$(uname -m)' is not supported yet"
                             exit 1
                             ;;
                         esac
                         
                         function url_exists {
                           local url="${1}"
                           curl -o /dev/null -sIf "$url"
                         }
                         
                         # Get tags in new order. The newest tag is first, the oldest tag is last.
                         tags=$(git ls-remote --refs --tags "https://github.com/${mitamae_repo}" \
                           | cut -d '/' -f 3 | sort -Vr)
                         for tag in ${tags}; do
                           url="https://github.com/${mitamae_repo}/releases/download/${tag}/mitamae-${mitamae_arch}-${mitamae_os}"
                           # TODO: support .tar.gz in mitamae-build
                           if [[ $mitamae_repo == "itamae-kitchen/mitamae-build" ]]; then
                             # If the URL exists, download it.
                             if url_exists "${url}"; then
                               curl -fL "${url}" > "./mitamae-${mitamae_arch}-${mitamae_os}"
                               echo "mitamae '${tag}' is downloaded"
                               break
                             fi
                           else
                             url="${url}.tar.gz"
                             if url_exists "${url}"; then
                               curl -fL "${url}" | tar xvz
                               echo "mitamae '${tag}' is downloaded"
                               break
                             fi
                           fi
                         done
                         
                         mv "mitamae-${mitamae_arch}-${mitamae_os}" /usr/local/bin/mitamae
                         chmod +x /usr/local/bin/mitamae
                         /usr/local/bin/mitamae version
$ bash
[fedora32.rubyci.org/ERR]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[fedora32.rubyci.org/ERR]                                  Dload  Upload   Total   Spent    Left  Speed
100   633  100   633    0     0  39562      0 --:--:-- --:--:-- --:--:-- 42200
[fedora32.rubyci.org] mitamae-x86_64-linux
100  641k  100  641k    0     0  2037k      0 --:--:-- --:--:-- --:--:-- 2037k
[fedora32.rubyci.org] mitamae 'v1.12.7' is downloaded
[fedora32.rubyci.org] mitamae v1.12.7
$ test -x /usr/local/bin/mitamae
$ umask 0077 && cat > /tmp/hocho-run-z0EJRnvPY/node.json
=> fedora32.rubyci.org # /usr/local/bin/mitamae local -j /tmp/hocho-run-z0EJRnvPY/node.json --log-level info --dry-run recipes/default.rb
$ bash
[fedora32.rubyci.org]  INFO : Starting mitamae...
[fedora32.rubyci.org]  INFO : Recipe: /tmp/hocho-run-z0EJRnvPY/itamae/recipes/default.rb
[fedora32.rubyci.org]  INFO :   Recipe: /tmp/hocho-run-z0EJRnvPY/itamae/recipes/setup-users.rb
[fedora32.rubyci.org]  INFO :   Recipe: /tmp/hocho-run-z0EJRnvPY/itamae/plugins/itamae-plugin-recipe-rbenv/mrblib/itamae/plugin/recipe/rbenv/user.rb
[fedora32.rubyci.org]  INFO :     Recipe: /tmp/hocho-run-z0EJRnvPY/itamae/plugins/itamae-plugin-recipe-rbenv/mrblib/itamae/plugin/recipe/rbenv/install.rb
[fedora32.rubyci.org]  INFO :       Recipe: /tmp/hocho-run-z0EJRnvPY/itamae/plugins/itamae-plugin-recipe-rbenv/mrblib/itamae/plugin/recipe/rbenv/development_dependency.rb
[fedora32.rubyci.org]  INFO :       Recipe: /tmp/hocho-run-z0EJRnvPY/itamae/plugins/itamae-plugin-recipe-rbenv/mrblib/itamae/plugin/recipe/rbenv/dependency.rb
=> fedora32.rubyci.org $ rm -rf /tmp/hocho-run-z0EJRnvPY/itamae
$ rm -rf /tmp/hocho-run-z0EJRnvPY/itamae
```

Now the version is printed in the log. I am printing both the `${tag}` value and the actual `mitamae version` considering the versions might be different by a bug.

```
[fedora32.rubyci.org] mitamae 'v1.12.7' is downloaded
[fedora32.rubyci.org] mitamae v1.12.7
```

Then checked the vlaue manually by doing SSH login.

```
[jaruga@fedora32 bin]$ /usr/local/bin/mitamae version
mitamae v1.12.7
```
