### PR TITLE
README: Add a note for arm64-neoverse-n1 server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ sudo emerge eix
 sudo eix-update # to be automated too
 ```
 
+### Ubuntu (jammy, arm64-neoverse-n1)
+
+We applied [a workaround](https://github.com/ruby/spec/issues/1095#issuecomment-1770537299) to setup `/etc/resolv.conf` properly in Ubuntu jammy on the arm64-neoverse-n1 server.
+
 ### Run hocho
 
 The specified domain is equivalent with the `Host <ip address>` in the `~/.ssh/config`.


### PR DESCRIPTION
I added a note to setup `/etc/resolv.conf` in the arm64-neoverse-n1 server on README.

The modified README is [here](https://github.com/junaruga/ruby-infra-recipe/blob/wip/readme-arm64-neoverse/README.md).