### PR TITLE
Removed the arm64-neoverse-n1 host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,6 @@ sudo emerge eix
 sudo eix-update # to be automated too
 ```
 
-### Ubuntu (jammy, arm64-neoverse-n1)
-
-We applied [a workaround](https://github.com/ruby/spec/issues/1095#issuecomment-1770537299) to setup `/etc/resolv.conf` properly in Ubuntu jammy on the arm64-neoverse-n1 server.
-
 ### Run hocho
 
 The specified domain is equivalent with the `Host <ip address>` in the `~/.ssh/config`.

--- a/hosts.yml
+++ b/hosts.yml
@@ -38,9 +38,6 @@ ubuntu.rubyci.org:
 riscv.rubyci.org:
   <<: *default
 
-arm64-neoverse-n1.rubyci.org: # neoverse n1
-  <<: *default
-
 ppc64le.rubyci.org: # power9
   <<: *default
 


### PR DESCRIPTION
See <https://bugs.ruby-lang.org/issues/20658> for the context and details.