### PR TITLE
Automate initial host setup and chkbuild crontab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "hocho", ">= 0.3.7"
-gem "bcrypt_pbkdf"
+# The precompiled arm64-darwin gem only bundles binaries for Ruby 2.7-3.3
+gem "bcrypt_pbkdf", force_ruby_platform: true
 gem "ed25519"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,4 +42,4 @@ DEPENDENCIES
   hocho (>= 0.3.7)
 
 BUNDLED WITH
-   2.7.1
+  4.0.16

--- a/README.md
+++ b/README.md
@@ -3,46 +3,25 @@
 ## Usage
 
 ### Prepare environment for hocho apply
-(some of them are to be automated using hocho)
 
-1. Add the ssh configuration to `~/.ssh/config` for your machine as follows. The `Host <ip address>` is used as an argument of the `hocho apply` later.
-
-    ```
-    Host debian.rubyci.org
-      User=<user>
-      IdentityFile <path to key>
-    ```
-
-2. Install `which`, `curl`, `git` and `rsync` commands in the target VM server.
-3. Add the `NOPASSWD` option to `/etc/sudoers` for your logined user in the target VM server.
-
-### RHEL
-
-You should enable CodeReady Linux Builder repository for RHEL 9 or later.
+After launching a VM and assigning the Elastic IP (DNS records are managed under `dns/`), bootstrap the host with the cloud image's default user:
 
 ```bash
-sudo yum-config-manager --enable codeready-builder-for-rhel-$VERSION-rhui-rpms
+bin/bootstrap -i ~/.ssh/aws-keypair.pem fedora@fedora44-arm.rubyci.org
 ```
 
-or
+The `-i` key is the AWS keypair injected at instance launch. Omit it if the keypair is available via your ssh agent.
 
-```bash
-sudo dnf config-manager --set-enabled codeready-builder-for-rhel-$VERSION-rhui-rpms
-```
+This streams `bin/bootstrap-remote.sh` over ssh and automates the previous manual steps:
 
-You can confirm these repos with the following command.
+- installs `which`, `curl`, `git` and `rsync`
+- creates your admin user with `recipes/keys/<you>.keys` and NOPASSWD sudo
+- enables CodeReady Linux Builder repository on RHEL
+- installs `sudo` and `bash` on FreeBSD
 
-```bash
-sudo yum repolist --all
-```
+No `~/.ssh/config` entry is needed. After bootstrap, `bin/hocho apply` connects as your own user. If the Elastic IP was reused from another host, remove the stale host key with `ssh-keygen -R <host>` first.
 
-### FreeBSD
-(to be automated using hocho)
-
-```bash
-pkg install sudo # then add NOPASSWD with visudo
-pkg install bash
-```
+Supported platforms: Fedora, RHEL, CentOS, Amazon Linux, Debian, Ubuntu, openSUSE, Arch and FreeBSD. Use the manual steps below for the others.
 
 ### OpenBSD
 (to be automated using hocho)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ bin/hocho apply -n debian.rubyci.org
 bin/hocho apply debian.rubyci.org
 ```
 
+### chkbuild crontab
+
+The chkbuild user's crontab is installed only when AWS credentials are given via environment variables at apply time. Without them the crontab is left untouched. `RUBYCI_NICKNAME` is derived from the host name (e.g. `fedora44-arm`).
+
+```bash
+CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho apply fedora44-arm.rubyci.org
+```
+
 ### All chkbuild
 
 ```bash

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Bootstrap a freshly launched VM so that `bin/hocho apply` can run against it.
+# Automates the manual steps in README.md: installs base packages, creates the
+# admin user with keys from recipes/keys/, and sets up NOPASSWD sudo.
+#
+# Usage: bin/bootstrap [-i identity_file] <initial_user>@<host> [<admin_user>]
+#   e.g. bin/bootstrap -i ~/.ssh/aws-keypair.pem fedora@fedora44-arm.rubyci.org
+#
+# <initial_user> is the cloud image's default user (fedora, ec2-user, admin, ...)
+# and authenticates with the AWS keypair injected at instance launch, given
+# with -i (omit it if the keypair is available via your ssh agent).
+# <admin_user> defaults to $USER and must have recipes/keys/<admin_user>.keys.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage="usage: bin/bootstrap [-i identity_file] <initial_user>@<host> [<admin_user>]"
+
+identity=""
+while getopts i: opt; do
+  case "$opt" in
+  i) identity="$OPTARG" ;;
+  *) echo "$usage" >&2; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+target="${1:?${usage}}"
+admin="${2:-$USER}"
+host="${target#*@}"
+keyfile="recipes/keys/${admin}.keys"
+
+if [[ ! -f "$keyfile" ]]; then
+  echo "error: ${keyfile} not found" >&2
+  exit 1
+fi
+
+ssh_opts=(-o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new)
+init_opts=("${ssh_opts[@]}")
+if [[ -n "$identity" ]]; then
+  init_opts+=(-i "$identity" -o IdentitiesOnly=yes)
+fi
+
+echo "Waiting for sshd on ${target} ..."
+for i in {1..30}; do
+  if ssh "${init_opts[@]}" "$target" true 2>/dev/null; then
+    break
+  fi
+  if [[ $i -eq 30 ]]; then
+    echo "error: cannot reach ${target} via ssh" >&2
+    echo "hint: if the Elastic IP was reused, run: ssh-keygen -R ${host}" >&2
+    exit 1
+  fi
+  sleep 10
+done
+
+echo "Bootstrapping ${host} (admin user: ${admin}) ..."
+{
+  printf 'admin=%q\n' "$admin"
+  cat bin/bootstrap-remote.sh
+  echo "install_keys <<'BOOTSTRAP_KEYS'"
+  cat "$keyfile"
+  echo "BOOTSTRAP_KEYS"
+} | ssh "${init_opts[@]}" "$target" 'sudo -n sh -s'
+
+echo "Verifying login as ${admin}@${host} ..."
+ssh "${ssh_opts[@]}" -o BatchMode=yes -l "$admin" "$host" 'sudo -n echo OK'
+
+cat <<NEXT
+Done. Next steps:
+  bin/hocho apply -n ${host}
+  bin/hocho apply ${host}
+NEXT

--- a/bin/bootstrap-remote.sh
+++ b/bin/bootstrap-remote.sh
@@ -1,0 +1,85 @@
+# Executed as root on the target host, streamed over ssh by `bin/bootstrap`.
+# Expects `admin=<name>` to be prepended to this stream, and an
+# `install_keys <<'BOOTSTRAP_KEYS' ... BOOTSTRAP_KEYS` call appended after it.
+set -eu
+
+: "${admin:?admin user is not set}"
+
+os="$(uname -s)"
+distro=unknown
+if [ -r /etc/os-release ]; then
+  . /etc/os-release
+  distro="$ID"
+fi
+
+case "$os" in
+Linux)
+  case "$distro" in
+  fedora|amzn|centos)
+    dnf install -y which curl git rsync
+    ;;
+  rhel)
+    dnf install -y which curl git rsync
+    dnf config-manager --set-enabled "codeready-builder-for-rhel-${VERSION_ID%%.*}-rhui-rpms"
+    ;;
+  debian|ubuntu)
+    apt-get update -q
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl git rsync
+    ;;
+  opensuse*|sles)
+    zypper --non-interactive install which curl git rsync
+    ;;
+  arch)
+    pacman -Sy --noconfirm --needed which curl git rsync
+    ;;
+  *)
+    echo "bootstrap: unsupported distro '$distro'" >&2
+    exit 1
+    ;;
+  esac
+  ;;
+FreeBSD)
+  env ASSUME_ALWAYS_YES=yes pkg install -y sudo bash curl git rsync
+  ;;
+*)
+  echo "bootstrap: unsupported OS '$os'" >&2
+  exit 1
+  ;;
+esac
+
+# Same gid mapping as recipes/setup-users.rb
+shell=""
+case "$distro" in
+debian|ubuntu) gid=27; shell=/bin/bash ;; # sudo
+opensuse*) gid=100 ;;                     # users (workaround no wheel)
+arch) gid=998 ;;                          # wheel
+*) gid=10 ;;                              # wheel
+esac
+if [ "$os" = FreeBSD ]; then gid=0; fi    # wheel
+
+if ! id "$admin" >/dev/null 2>&1; then
+  if [ "$os" = FreeBSD ]; then
+    pw useradd -n "$admin" -g "$gid" -m
+  else
+    useradd -m -g "$gid" ${shell:+-s "$shell"} "$admin"
+  fi
+fi
+
+home=$(getent passwd "$admin" | cut -d: -f6)
+mkdir -p "$home/.ssh"
+chmod 755 "$home"
+chmod 700 "$home/.ssh"
+
+sudoers_dir=/etc/sudoers.d
+if [ "$os" = FreeBSD ]; then sudoers_dir=/usr/local/etc/sudoers.d; fi
+mkdir -p "$sudoers_dir"
+printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$admin" > "$sudoers_dir/50-$admin"
+chmod 440 "$sudoers_dir/50-$admin"
+visudo -cf "$sudoers_dir/50-$admin"
+
+install_keys() {
+  cat > "$home/.ssh/authorized_keys"
+  chmod 600 "$home/.ssh/authorized_keys"
+  chown -R "$admin" "$home/.ssh"
+  echo "bootstrap: completed for ${admin}@$(hostname)"
+}

--- a/hocho.yml
+++ b/hocho.yml
@@ -2,6 +2,20 @@ property_providers:
   - add_default:
       properties:
         preferred_driver: mitamae
+  # Derive RUBYCI_NICKNAME from the host name and inject AWS credentials
+  # for the chkbuild crontab from environment variables at apply time.
+  - ruby_script:
+      script: |
+        return unless host.name.end_with?('.rubyci.org')
+        chkbuild = { nickname: host.name.split('.').first }
+        if ENV['CHKBUILD_AWS_ACCESS_KEY_ID'] && ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']
+          chkbuild[:aws_access_key_id] = ENV['CHKBUILD_AWS_ACCESS_KEY_ID']
+          chkbuild[:aws_secret_access_key] = ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']
+        end
+        # NOTE: assign, then re-read; Hashie::Mash stores a converted copy,
+        # so mutating the right-hand value of `||=` would be lost.
+        host.properties[:attributes] ||= {}
+        host.properties[:attributes][:chkbuild] = chkbuild
 
 driver_options:
   mitamae:

--- a/hocho.yml
+++ b/hocho.yml
@@ -15,6 +15,7 @@ property_providers:
         # NOTE: assign, then re-read; Hashie::Mash stores a converted copy,
         # so mutating the right-hand value of `||=` would be lost.
         host.properties[:attributes] ||= {}
+        host.properties[:attributes][:fqdn] = host.name
         host.properties[:attributes][:chkbuild] = chkbuild
 
 driver_options:

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -1,0 +1,27 @@
+# Install the chkbuild user's crontab. AWS credentials are injected into
+# node[:chkbuild] by the ruby_script property provider in hocho.yml only
+# when CHKBUILD_AWS_ACCESS_KEY_ID/CHKBUILD_AWS_SECRET_ACCESS_KEY are set
+# at apply time; otherwise the crontab is left untouched.
+chkbuild = node[:chkbuild] || {}
+
+if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
+  crontab_path = "/home/chkbuild/.crontab"
+
+  file crontab_path do
+    owner 'chkbuild'
+    mode '600'
+    content <<~CRON
+      MAILTO=""
+      AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}
+      AWS_SECRET_ACCESS_KEY=#{chkbuild[:aws_secret_access_key]}
+      RUBYCI_NICKNAME=#{chkbuild[:nickname]}
+      30 */3 * * * cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby start-rubyci && rm -rf tmp/build
+    CRON
+  end
+
+  execute "crontab -u chkbuild #{crontab_path}" do
+    not_if "crontab -l -u chkbuild 2>/dev/null | cmp -s - #{crontab_path}"
+  end
+else
+  MItamae.logger.info "skipping chkbuild crontab (no AWS credentials given)"
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,3 +1,4 @@
+include_recipe "hostname"
 include_recipe "setup-users"
 
 user 'chkbuild' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,3 +83,5 @@ when 'gentoo'
     action [:enable, :start]
   end
 end
+
+include_recipe "chkbuild-cron"

--- a/recipes/hostname.rb
+++ b/recipes/hostname.rb
@@ -1,0 +1,21 @@
+# Set the hostname to the rubyci FQDN (e.g. fedora44-arm.rubyci.org).
+# node[:fqdn] is injected by the ruby_script property provider in hocho.yml
+# for *.rubyci.org hosts only, so other hosts are left untouched.
+fqdn = node[:fqdn]
+
+if fqdn && !fqdn.empty?
+  case node[:platform]
+  when 'freebsd'
+    execute "sysrc hostname=#{fqdn} && hostname #{fqdn}" do
+      not_if %Q(test "$(hostname)" = #{fqdn})
+    end
+  when 'openbsd'
+    execute "echo #{fqdn} > /etc/myname && hostname #{fqdn}" do
+      not_if %Q(test "$(hostname)" = #{fqdn})
+    end
+  else
+    execute "hostnamectl set-hostname #{fqdn}" do
+      not_if %Q(test "$(hostname)" = #{fqdn})
+    end
+  end
+end


### PR DESCRIPTION
Setting up a new rubyci host still required manual steps after launching the instance and assigning the Elastic IP. This adds `bin/bootstrap`, which streams `bin/bootstrap-remote.sh` over ssh with the AWS keypair to install base packages and create the admin user from `recipes/keys/` with NOPASSWD sudo, so `bin/hocho apply` works right away without a `~/.ssh/config` entry.

```
bin/bootstrap -i ~/.ssh/aws-keypair.pem fedora@fedora44-arm.rubyci.org
CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho apply fedora44-arm.rubyci.org
```

The chkbuild crontab is now managed by hocho. AWS credentials are given as environment variables at apply time and never stored in the repository. The hostname is also set to the rubyci FQDN. `bcrypt_pbkdf` is forced to the ruby platform because the precompiled gem lacks binaries for Ruby 4.x, which broke ed25519 agent authentication in net-ssh. Verified on `fedora44-arm.rubyci.org`.

Fixes #26

Generated with [Claude Code](https://claude.com/claude-code)
