### PR TITLE
Remove retired amazon2 host

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -5,13 +5,6 @@ debian.rubyci.org:
     run_list:
       - recipes/default.rb
 
-amazon2.rubyci.org:
-  properties:
-    nopasswd_sudo: true
-    compress: false
-    run_list:
-      - recipes/default.rb
-
 opensuseleap.rubyci.org:
   properties:
     nopasswd_sudo: true


### PR DESCRIPTION
`amazon2.rubyci.org` no longer resolves. Its DNS record was intentionally removed in 465d5d2 along with other stale records, and Amazon Linux 2 is retired from the rubyci fleet, superseded by `amazon2023.rubyci.org`. This removes the leftover entry from `hosts.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
