### PR TITLE
Add bin/os-update and bin/all-hosts for fleet-wide OS updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,33 +65,33 @@ CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho appl
 
 ### All chkbuild
 
+`bin/all-hosts` runs a command for every host in `hosts.yml` in parallel, appending the host name as the last argument. Full per-host output goes to `$TMPDIR/all-hosts-<timestamp>/<host>.log` and a summary is printed at the end. Use `-j N` to limit concurrency.
+
 ```bash
-# check if you can login
-for i in $(bin/hosts); do bash -cx "ssh ${i} echo OK"; done
+# check if you can login (the host name is appended as the last argument)
+bin/all-hosts sh -c 'ssh -o BatchMode=yes "$0" echo OK'
 
 # dry-run
-for i in $(bin/hosts); do bundle exec hocho apply -n "${i}"; done
+bin/all-hosts bin/hocho apply -n
 
 # apply
-for i in $(bin/hosts); do bundle exec hocho apply "${i}"; done
+bin/all-hosts bin/hocho apply
 ```
 
 ### OS updates
 
-`bin/os-update` runs OS package updates on every host in `hosts.yml` in parallel over ssh. It detects the platform on each host and picks the right command (dnf, yum, apt, zypper, pacman, pkg + freebsd-update). OpenBSD is updated by its own maintainer and is always skipped. Reboots are never performed automatically; hosts that need one are reported in the summary.
+`bin/os-update` runs OS package updates on a single host over ssh. It detects the platform on the host and picks the right command (dnf, yum, apt, zypper, pacman, pkg + freebsd-update). OpenBSD is updated by its own maintainer and is always skipped. Reboots are never performed; the final output line reports whether one is needed.
 
 ```bash
 # check for pending updates only
-bin/os-update -n
+bin/os-update -n fedora43.rubyci.org
 
-# apply updates on all hosts
-bin/os-update
+# apply updates
+bin/os-update fedora43.rubyci.org
 
-# apply updates on specific hosts
-bin/os-update fedora43.rubyci.org ubuntu2404.rubyci.org
+# all hosts
+bin/all-hosts bin/os-update
 ```
-
-Full per-host output is written to `$TMPDIR/os-update-<timestamp>/<host>.log`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ for i in $(bin/hosts); do bundle exec hocho apply "${i}"; done
 
 ### OS updates
 
-`bin/os-update` runs OS package updates on every host in `hosts.yml` in parallel over ssh. It detects the platform on each host and picks the right command (dnf, yum, apt, zypper, pacman, pkg + freebsd-update, syspatch + pkg_add). Reboots are never performed automatically; hosts that need one are reported in the summary.
+`bin/os-update` runs OS package updates on every host in `hosts.yml` in parallel over ssh. It detects the platform on each host and picks the right command (dnf, yum, apt, zypper, pacman, pkg + freebsd-update). OpenBSD is updated by its own maintainer and is always skipped. Reboots are never performed automatically; hosts that need one are reported in the summary.
 
 ```bash
 # check for pending updates only

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ for i in $(bin/hosts); do bundle exec hocho apply -n "${i}"; done
 for i in $(bin/hosts); do bundle exec hocho apply "${i}"; done
 ```
 
+### OS updates
+
+`bin/os-update` runs OS package updates on every host in `hosts.yml` in parallel over ssh. It detects the platform on each host and picks the right command (dnf, yum, apt, zypper, pacman, pkg + freebsd-update, syspatch + pkg_add). Reboots are never performed automatically; hosts that need one are reported in the summary.
+
+```bash
+# check for pending updates only
+bin/os-update -n
+
+# apply updates on all hosts
+bin/os-update
+
+# apply updates on specific hosts
+bin/os-update fedora43.rubyci.org ubuntu2404.rubyci.org
+```
+
+Full per-host output is written to `$TMPDIR/os-update-<timestamp>/<host>.log`.
+
 ## License
 
 [Ruby License](https://www.ruby-lang.org/en/about/license.txt)

--- a/bin/all-hosts
+++ b/bin/all-hosts
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Run a command for every host in hosts.yml, appending the host name as the
+# last argument.
+#
+# Usage: bin/all-hosts [-j N] <command> [args...]
+#   -j N  run at most N hosts at a time (default: all in parallel)
+#
+#   bin/all-hosts bin/os-update -n
+#   bin/all-hosts bin/hocho apply
+#
+# Full per-host output goes to $TMPDIR/all-hosts-<timestamp>/<host>.log and a
+# summary with each host's exit status and last output line is printed at the
+# end. Exits non-zero if the command failed on any host.
+
+require 'fileutils'
+require 'open3'
+require 'optparse'
+require 'yaml'
+
+jobs = nil
+opt = OptionParser.new
+opt.banner = 'usage: bin/all-hosts [-j N] <command> [args...]'
+opt.on('-j N', Integer, 'run at most N hosts at a time') { |n| jobs = n }
+command = opt.order(ARGV)
+abort opt.banner if command.empty?
+
+Dir.chdir(File.expand_path('..', __dir__))
+hosts = YAML.load_file('hosts.yml').keys
+
+log_dir = File.join(ENV['TMPDIR'] || '/tmp', "all-hosts-#{Time.now.strftime('%Y%m%d-%H%M%S')}")
+FileUtils.mkdir_p(log_dir)
+
+queue = Queue.new
+hosts.each { |host| queue << host }
+results = {}
+mutex = Mutex.new
+
+threads = Array.new([jobs || hosts.size, hosts.size].min) do
+  Thread.new do
+    until queue.empty?
+      host = begin
+        queue.pop(true)
+      rescue ThreadError
+        break
+      end
+      out, status = Open3.capture2e(*command, host)
+      File.write(File.join(log_dir, "#{host}.log"), out)
+      last_line = out.lines.map(&:chomp).reject(&:empty?).last.to_s
+      result = status.success? ? 'ok' : "FAILED(#{status.exitstatus})"
+      mutex.synchronize { results[host] = [result, last_line] }
+      warn format('%-34s %-12s %s', host, result, last_line)
+    end
+  end
+end
+threads.each(&:join)
+
+puts
+puts format('%-34s %-12s %s', 'HOST', 'EXIT', 'LAST LINE')
+hosts.each do |host|
+  result, last_line = results[host]
+  puts format('%-34s %-12s %s', host, result, last_line)
+end
+puts
+puts "logs: #{log_dir}"
+exit 1 if results.any? { |_, (result, _)| result != 'ok' }

--- a/bin/os-update
+++ b/bin/os-update
@@ -1,38 +1,27 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-# Run OS package updates on hosts in hosts.yml in parallel over ssh.
+# Run OS package updates on a single host over ssh.
 #
-# Usage: bin/os-update [-n] [host ...]
+# Usage: bin/os-update [-n] <host>
 #   -n  check for pending updates only, do not apply
 #
 # Connects as your own user (same as bin/hocho) and relies on NOPASSWD sudo.
-# Full per-host output goes to $TMPDIR/os-update-<timestamp>/<host>.log and
-# a one-line-per-host summary is printed at the end. Reboots are never
-# performed automatically; hosts that need one are reported as "reboot".
+# Reboots are never performed; the final line reports whether one is needed.
+# Use `bin/all-hosts bin/os-update` to run this on every host in hosts.yml.
 
-require 'fileutils'
-require 'open3'
 require 'optparse'
-require 'yaml'
 
 mode = 'apply'
 opt = OptionParser.new
-opt.banner = 'usage: bin/os-update [-n] [host ...]'
+opt.banner = 'usage: bin/os-update [-n] <host>'
 opt.on('-n', 'check for pending updates only') { mode = 'check' }
-filter = opt.parse(ARGV)
+args = opt.parse(ARGV)
+abort opt.banner unless args.size == 1
+host = args.first
 
-Dir.chdir(File.expand_path('..', __dir__))
-hosts = YAML.load_file('hosts.yml').keys
-unless filter.empty?
-  unknown = filter - hosts
-  abort "error: unknown host(s): #{unknown.join(', ')}" unless unknown.empty?
-  hosts = filter
-end
-
-# Streamed to each host via `ssh <host> sh -s`. POSIX sh: no local, no arrays.
-# The wrapper prepends MODE=apply|check. Markers on stdout report the result:
-#   OSUPDATE:STATUS:clean|pending|updated|skipped
-#   OSUPDATE:REBOOT:yes|no
+# Streamed to the host via `ssh <host> sh -s`. POSIX sh: no local, no arrays.
+# The wrapper prepends MODE=apply|check. The last line reports the result:
+#   os-update: status=clean|pending|updated|skipped reboot=yes|no
 REMOTE_SCRIPT = <<~'SH'
   set -u
   export LC_ALL=C
@@ -158,40 +147,14 @@ REMOTE_SCRIPT = <<~'SH'
   elif [ "$pending" = yes ]; then status=pending
   else status=clean
   fi
-  echo "OSUPDATE:STATUS:$status"
-  echo "OSUPDATE:REBOOT:$reboot"
+  echo "os-update: status=$status reboot=$reboot"
 SH
 
-log_dir = File.join(ENV['TMPDIR'] || '/tmp', "os-update-#{Time.now.strftime('%Y%m%d-%H%M%S')}")
-FileUtils.mkdir_p(log_dir)
 ssh_opts = %w[-o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=30]
-
-threads = hosts.map do |host|
-  Thread.new do
-    out, ssh_status = Open3.capture2e('ssh', *ssh_opts, host, 'sh -s',
-                                      stdin_data: "MODE=#{mode}\n#{REMOTE_SCRIPT}")
-    File.write(File.join(log_dir, "#{host}.log"), out)
-    status = out[/^OSUPDATE:STATUS:(\S+)/, 1]
-    reboot = out[/^OSUPDATE:REBOOT:(\S+)/, 1]
-    result =
-      if ssh_status.exitstatus == 255
-        'UNREACHABLE'
-      elsif !ssh_status.success? || status.nil?
-        'FAILED'
-      else
-        status
-      end
-    warn format('%-34s %s', host, result)
-    [host, result, reboot]
-  end
-end
-results = threads.map(&:value)
-
-puts
-puts format('%-34s %-12s %s', 'HOST', 'STATUS', 'REBOOT')
-results.each do |host, result, reboot|
-  puts format('%-34s %-12s %s', host, result, reboot == 'yes' ? 'required' : '')
-end
-puts
-puts "logs: #{log_dir}"
-exit 1 if results.any? { |_, result, _| %w[FAILED UNREACHABLE].include?(result) }
+reader, writer = IO.pipe
+pid = spawn('ssh', *ssh_opts, host, 'sh -s', in: reader)
+reader.close
+writer.write("MODE=#{mode}\n#{REMOTE_SCRIPT}")
+writer.close
+Process.wait(pid)
+exit $?.exitstatus

--- a/bin/os-update
+++ b/bin/os-update
@@ -135,23 +135,6 @@ REMOTE_SCRIPT = <<~'SH'
     fi
   }
 
-  update_openbsd() {
-    sp=$(sudo -n syspatch -c 2>&1) || true
-    echo "$sp"
-    if [ -n "$sp" ]; then
-      pending=yes
-      if [ "$MODE" = apply ]; then
-        run syspatch || exit 1
-        updated=yes reboot=yes
-      fi
-    fi
-    if [ "$MODE" = apply ]; then
-      run pkg_add -u || exit 1
-    else
-      sudo -n pkg_add -u -n || exit 1
-    fi
-  }
-
   echo "== $(hostname) / $(uname -srm) / mode=$MODE"
   case "$(uname -s)" in
   Linux)
@@ -165,7 +148,8 @@ REMOTE_SCRIPT = <<~'SH'
     esac
     ;;
   FreeBSD) update_freebsd ;;
-  OpenBSD) update_openbsd ;;
+  # OpenBSD is updated by its own maintainer; never touch it from here
+  OpenBSD) echo "OpenBSD is maintained by hand; skipping"; skipped=yes ;;
   *) echo "unsupported OS: $(uname -s)"; skipped=yes ;;
   esac
 

--- a/bin/os-update
+++ b/bin/os-update
@@ -1,0 +1,213 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Run OS package updates on hosts in hosts.yml in parallel over ssh.
+#
+# Usage: bin/os-update [-n] [host ...]
+#   -n  check for pending updates only, do not apply
+#
+# Connects as your own user (same as bin/hocho) and relies on NOPASSWD sudo.
+# Full per-host output goes to $TMPDIR/os-update-<timestamp>/<host>.log and
+# a one-line-per-host summary is printed at the end. Reboots are never
+# performed automatically; hosts that need one are reported as "reboot".
+
+require 'fileutils'
+require 'open3'
+require 'optparse'
+require 'yaml'
+
+mode = 'apply'
+opt = OptionParser.new
+opt.banner = 'usage: bin/os-update [-n] [host ...]'
+opt.on('-n', 'check for pending updates only') { mode = 'check' }
+filter = opt.parse(ARGV)
+
+Dir.chdir(File.expand_path('..', __dir__))
+hosts = YAML.load_file('hosts.yml').keys
+unless filter.empty?
+  unknown = filter - hosts
+  abort "error: unknown host(s): #{unknown.join(', ')}" unless unknown.empty?
+  hosts = filter
+end
+
+# Streamed to each host via `ssh <host> sh -s`. POSIX sh: no local, no arrays.
+# The wrapper prepends MODE=apply|check. Markers on stdout report the result:
+#   OSUPDATE:STATUS:clean|pending|updated|skipped
+#   OSUPDATE:REBOOT:yes|no
+REMOTE_SCRIPT = <<~'SH'
+  set -u
+  export LC_ALL=C
+  pending=no updated=no skipped=no reboot=no
+
+  run() { echo "+ sudo $*"; sudo -n "$@"; }
+
+  update_rpm() {
+    pkg=dnf
+    command -v dnf >/dev/null 2>&1 || pkg=yum
+    sudo -n "$pkg" -q check-update
+    case $? in
+    0) ;;
+    100)
+      pending=yes
+      if [ "$MODE" = apply ]; then
+        run "$pkg" -y upgrade || exit 1
+        updated=yes
+      fi
+      ;;
+    *) exit 1 ;;
+    esac
+    if command -v needs-restarting >/dev/null 2>&1; then
+      sudo -n needs-restarting -r >/dev/null 2>&1 || reboot=yes
+    fi
+  }
+
+  update_deb() {
+    run apt-get -q update || exit 1
+    sim=$(sudo -n apt-get -qs dist-upgrade) || exit 1
+    echo "$sim" | grep '^Inst '
+    if [ "$(echo "$sim" | grep -c '^Inst ')" -gt 0 ]; then
+      pending=yes
+      if [ "$MODE" = apply ]; then
+        run env DEBIAN_FRONTEND=noninteractive apt-get -y \
+          -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold \
+          dist-upgrade || exit 1
+        updated=yes
+      fi
+    fi
+    [ -f /var/run/reboot-required ] && reboot=yes
+  }
+
+  update_suse() {
+    run zypper --non-interactive refresh || exit 1
+    lu=$(sudo -n zypper --non-interactive list-updates) || exit 1
+    echo "$lu"
+    if ! echo "$lu" | grep -q 'No updates found'; then
+      pending=yes
+      if [ "$MODE" = apply ]; then
+        run zypper --non-interactive update
+        rc=$?
+        # zypper exit codes >= 100 are informational, not errors
+        [ "$rc" -eq 0 ] || [ "$rc" -ge 100 ] || exit 1
+        updated=yes
+      fi
+    fi
+    sudo -n zypper needs-rebooting >/dev/null 2>&1
+    [ $? -eq 102 ] && reboot=yes
+  }
+
+  update_arch() {
+    run pacman -Sy --noconfirm || exit 1
+    if pacman -Qu; then
+      pending=yes
+      if [ "$MODE" = apply ]; then
+        # refresh the keyring first so signatures on long-idle hosts verify
+        run pacman -S --needed --noconfirm archlinux-keyring || exit 1
+        run pacman -Su --noconfirm || exit 1
+        updated=yes
+      fi
+    fi
+  }
+
+  update_freebsd() {
+    run pkg update -q || exit 1
+    sim=$(sudo -n pkg upgrade -n 2>&1)
+    echo "$sim"
+    # "up to date" also appears in the repository catalogue messages, so
+    # detect pending work by the action summary lines instead
+    if echo "$sim" | grep -q '^Number of packages to be'; then
+      pending=yes
+      if [ "$MODE" = apply ]; then
+        run pkg upgrade -y || exit 1
+        updated=yes
+      fi
+    fi
+    # base system: best effort, freebsd-update is unsupported on STABLE/CURRENT
+    if fu=$(sudo -n env PAGER=cat freebsd-update --not-running-from-cron fetch 2>&1); then
+      echo "$fu"
+      if sudo -n freebsd-update updatesready >/dev/null 2>&1; then
+        pending=yes
+        if [ "$MODE" = apply ]; then
+          run env PAGER=cat freebsd-update install || exit 1
+          updated=yes reboot=yes
+        fi
+      fi
+    else
+      echo "freebsd-update skipped: $fu"
+    fi
+  }
+
+  update_openbsd() {
+    sp=$(sudo -n syspatch -c 2>&1) || true
+    echo "$sp"
+    if [ -n "$sp" ]; then
+      pending=yes
+      if [ "$MODE" = apply ]; then
+        run syspatch || exit 1
+        updated=yes reboot=yes
+      fi
+    fi
+    if [ "$MODE" = apply ]; then
+      run pkg_add -u || exit 1
+    else
+      sudo -n pkg_add -u -n || exit 1
+    fi
+  }
+
+  echo "== $(hostname) / $(uname -srm) / mode=$MODE"
+  case "$(uname -s)" in
+  Linux)
+    . /etc/os-release
+    case "$ID" in
+    fedora|rhel|centos|almalinux|rocky|amzn) update_rpm ;;
+    debian|ubuntu) update_deb ;;
+    opensuse*|sles|sled) update_suse ;;
+    arch) update_arch ;;
+    *) echo "unsupported Linux distribution: $ID"; skipped=yes ;;
+    esac
+    ;;
+  FreeBSD) update_freebsd ;;
+  OpenBSD) update_openbsd ;;
+  *) echo "unsupported OS: $(uname -s)"; skipped=yes ;;
+  esac
+
+  if [ "$skipped" = yes ]; then status=skipped
+  elif [ "$updated" = yes ]; then status=updated
+  elif [ "$pending" = yes ]; then status=pending
+  else status=clean
+  fi
+  echo "OSUPDATE:STATUS:$status"
+  echo "OSUPDATE:REBOOT:$reboot"
+SH
+
+log_dir = File.join(ENV['TMPDIR'] || '/tmp', "os-update-#{Time.now.strftime('%Y%m%d-%H%M%S')}")
+FileUtils.mkdir_p(log_dir)
+ssh_opts = %w[-o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=30]
+
+threads = hosts.map do |host|
+  Thread.new do
+    out, ssh_status = Open3.capture2e('ssh', *ssh_opts, host, 'sh -s',
+                                      stdin_data: "MODE=#{mode}\n#{REMOTE_SCRIPT}")
+    File.write(File.join(log_dir, "#{host}.log"), out)
+    status = out[/^OSUPDATE:STATUS:(\S+)/, 1]
+    reboot = out[/^OSUPDATE:REBOOT:(\S+)/, 1]
+    result =
+      if ssh_status.exitstatus == 255
+        'UNREACHABLE'
+      elsif !ssh_status.success? || status.nil?
+        'FAILED'
+      else
+        status
+      end
+    warn format('%-34s %s', host, result)
+    [host, result, reboot]
+  end
+end
+results = threads.map(&:value)
+
+puts
+puts format('%-34s %-12s %s', 'HOST', 'STATUS', 'REBOOT')
+results.each do |host, result, reboot|
+  puts format('%-34s %-12s %s', host, result, reboot == 'yes' ? 'required' : '')
+end
+puts
+puts "logs: #{log_dir}"
+exit 1 if results.any? { |_, result, _| %w[FAILED UNREACHABLE].include?(result) }


### PR DESCRIPTION
OS updates on the rubyci hosts have been applied by logging in to each host and running `dnf update -y` by hand. `bin/os-update` runs the update for a single host over ssh, detecting the platform and picking the matching non-interactive command (`dnf`, `yum`, `apt`, `zypper`, `pacman`, `pkg` plus `freebsd-update`). Reboots are never performed and the final line reports whether one is needed, so an update that breaks chkbuild stays observable on rubyci.org. OpenBSD has its own maintainer and is always skipped. `bin/all-hosts` runs any command for every host in `hosts.yml` in parallel with per-host logs and an exit status summary, so it also covers `bin/hocho apply`.

```bash
bin/os-update -n fedora43.rubyci.org
bin/all-hosts bin/os-update
bin/all-hosts bin/hocho apply -n
```

Generated with [Claude Code](https://claude.com/claude-code)
