### PR TITLE
Tune chkbuild cron interval per host

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ bin/hocho apply debian.rubyci.org
 
 The chkbuild user's crontab is installed only when AWS credentials are given via environment variables at apply time. Without them the crontab is left untouched. `RUBYCI_NICKNAME` is derived from the host name (e.g. `fedora44-arm`).
 
+The cron interval defaults to every 3 hours and can be overridden per host with `attributes.chkbuild.schedule` in `hosts.yml`. The interval is sized from the measured duration of one full chkbuild cycle (all branches) on rubyci.org plus ~15 minutes of headroom, since chkbuild aborts when the previous run still holds its lock.
+
 ```bash
 CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho apply fedora44-arm.rubyci.org
 ```

--- a/hocho.yml
+++ b/hocho.yml
@@ -79,7 +79,7 @@ driver_options:
 
       function url_exists {
         local url="${1}"
-        curl -o /dev/null -sIf "$url"
+        curl -o /dev/null -sIfL "$url"
       }
 
       # Get tags in new order. The newest tag is first, the oldest tag is last.
@@ -88,12 +88,21 @@ driver_options:
       for tag in ${tags}; do
         url="https://github.com/${mitamae_repo}/releases/download/${tag}/mitamae-${mitamae_arch}-${mitamae_os}"
         if url_exists "${url}"; then
-          curl -fL "${url}" > "./mitamae-${mitamae_arch}-${mitamae_os}"
-          echo "mitamae '${tag}' is downloaded"
-          break
+          # The shell redirection creates the file even when curl fails, and a
+          # truncated/empty mitamae would get installed and then silently
+          # "succeed" on every later run. Keep only a verified download.
+          if curl -fL "${url}" > "./mitamae-${mitamae_arch}-${mitamae_os}"; then
+            echo "mitamae '${tag}' is downloaded"
+            break
+          fi
+          rm -f "./mitamae-${mitamae_arch}-${mitamae_os}"
         fi
       done
 
+      if [ ! -s "mitamae-${mitamae_arch}-${mitamae_os}" ]; then
+        echo "failed to download mitamae" >&2
+        exit 1
+      fi
       mv "mitamae-${mitamae_arch}-${mitamae_os}" /usr/local/bin/mitamae
       chmod +x /usr/local/bin/mitamae
       /usr/local/bin/mitamae version

--- a/hocho.yml
+++ b/hocho.yml
@@ -8,10 +8,13 @@ property_providers:
       script: |
         return unless host.name.end_with?('.rubyci.org')
         # Keep per-host chkbuild attributes from hosts.yml (e.g. schedule)
-        # and add the derived/injected values on top (Hashie::Mash, so
-        # indifferent access).
+        # and add the derived/injected values on top.
+        # Hashie::Mash, so indifferent access; do not .to_h (string keys would
+        # break the :nickname ||= below).
         chkbuild = host.properties.dig(:attributes, :chkbuild) || {}
-        chkbuild[:nickname] = host.name.split('.').first
+        # e.g. openbsd reports to rubyci as openbsd-current; keep an explicit
+        # nickname from hosts.yml over the host-name-derived one.
+        chkbuild[:nickname] ||= host.name.split('.').first
         if ENV['CHKBUILD_AWS_ACCESS_KEY_ID'] && ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']
           chkbuild[:aws_access_key_id] = ENV['CHKBUILD_AWS_ACCESS_KEY_ID']
           chkbuild[:aws_secret_access_key] = ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']

--- a/hocho.yml
+++ b/hocho.yml
@@ -7,7 +7,11 @@ property_providers:
   - ruby_script:
       script: |
         return unless host.name.end_with?('.rubyci.org')
-        chkbuild = { nickname: host.name.split('.').first }
+        # Keep per-host chkbuild attributes from hosts.yml (e.g. schedule)
+        # and add the derived/injected values on top (Hashie::Mash, so
+        # indifferent access).
+        chkbuild = host.properties.dig(:attributes, :chkbuild) || {}
+        chkbuild[:nickname] = host.name.split('.').first
         if ENV['CHKBUILD_AWS_ACCESS_KEY_ID'] && ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']
           chkbuild[:aws_access_key_id] = ENV['CHKBUILD_AWS_ACCESS_KEY_ID']
           chkbuild[:aws_secret_access_key] = ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']

--- a/hosts.yml
+++ b/hosts.yml
@@ -44,6 +44,9 @@ openbsd.rubyci.org:
   properties:
     attributes:
       chkbuild:
+        # Reports to rubyci.org as openbsd-current; the hostname itself is
+        # still set to openbsd.rubyci.org like every other host.
+        nickname: openbsd-current
         schedule: "30 */2 * * *"
     nopasswd_sudo: true
     compress: false

--- a/hosts.yml
+++ b/hosts.yml
@@ -42,6 +42,9 @@ debian11.rubyci.org:
 
 openbsd.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */2 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -63,6 +66,9 @@ riscv.rubyci.org:
 
 ppc64le.rubyci.org: # power9
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */4 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -91,6 +97,9 @@ ubuntu2204.rubyci.org:
 
 ubuntu2404.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */2 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -98,6 +107,9 @@ ubuntu2404.rubyci.org:
 
 crossruby.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */4 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -126,6 +138,9 @@ debian12.rubyci.org:
 
 freebsd14.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */2 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -140,6 +155,9 @@ ubuntu-arm.rubyci.org:
 
 debian13.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */2 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -147,6 +165,9 @@ debian13.rubyci.org:
 
 rhel10.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */2 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -161,6 +182,9 @@ fedora43.rubyci.org:
 
 freebsd15-arm.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */4 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -168,6 +192,9 @@ freebsd15-arm.rubyci.org:
 
 fedora44-arm.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "30 */2 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -12,19 +12,27 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
   # still holds its lock, so an overlap loses a whole cycle.
   schedule = chkbuild[:schedule] || '30 */3 * * *'
 
+  lines = [
+    'MAILTO=""',
+    "AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}",
+    "AWS_SECRET_ACCESS_KEY=#{chkbuild[:aws_secret_access_key]}",
+    "RUBYCI_NICKNAME=#{chkbuild[:nickname]}",
+  ]
+  if node[:platform] == 'freebsd' && node[:platform_version].to_i >= 15
+    # ruby built on FreeBSD 15 (pkgbase) does not find the system CA bundle
+    # by itself and every https access fails without this. Not needed on
+    # FreeBSD 14 and earlier.
+    lines << 'SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt'
+  end
+  lines << "#{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby start-rubyci && rm -rf tmp/build"
+  lines << ''
+
   # NOTE: no <<~ heredoc here; the mruby in mitamae <= 1.11 misparses it as
   # `content << ~CRON` and dies with NameError.
   file crontab_path do
     owner 'chkbuild'
     mode '600'
-    content [
-      'MAILTO=""',
-      "AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}",
-      "AWS_SECRET_ACCESS_KEY=#{chkbuild[:aws_secret_access_key]}",
-      "RUBYCI_NICKNAME=#{chkbuild[:nickname]}",
-      "#{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby start-rubyci && rm -rf tmp/build",
-      '',
-    ].join("\n")
+    content lines.join("\n")
   end
 
   execute "crontab -u chkbuild #{crontab_path}" do

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -12,16 +12,19 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
   # still holds its lock, so an overlap loses a whole cycle.
   schedule = chkbuild[:schedule] || '30 */3 * * *'
 
+  # NOTE: no <<~ heredoc here; the mruby in mitamae <= 1.11 misparses it as
+  # `content << ~CRON` and dies with NameError.
   file crontab_path do
     owner 'chkbuild'
     mode '600'
-    content <<~CRON
-      MAILTO=""
-      AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}
-      AWS_SECRET_ACCESS_KEY=#{chkbuild[:aws_secret_access_key]}
-      RUBYCI_NICKNAME=#{chkbuild[:nickname]}
-      #{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby start-rubyci && rm -rf tmp/build
-    CRON
+    content [
+      'MAILTO=""',
+      "AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}",
+      "AWS_SECRET_ACCESS_KEY=#{chkbuild[:aws_secret_access_key]}",
+      "RUBYCI_NICKNAME=#{chkbuild[:nickname]}",
+      "#{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby start-rubyci && rm -rf tmp/build",
+      '',
+    ].join("\n")
   end
 
   execute "crontab -u chkbuild #{crontab_path}" do

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -7,6 +7,11 @@ chkbuild = node[:chkbuild] || {}
 if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
   crontab_path = "/home/chkbuild/.crontab"
 
+  # Interval per host is chosen so that one full chkbuild cycle (all branches)
+  # plus ~15min headroom fits within it; chkbuild aborts when the previous run
+  # still holds its lock, so an overlap loses a whole cycle.
+  schedule = chkbuild[:schedule] || '30 */3 * * *'
+
   file crontab_path do
     owner 'chkbuild'
     mode '600'
@@ -15,7 +20,7 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
       AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}
       AWS_SECRET_ACCESS_KEY=#{chkbuild[:aws_secret_access_key]}
       RUBYCI_NICKNAME=#{chkbuild[:nickname]}
-      30 */3 * * * cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby start-rubyci && rm -rf tmp/build
+      #{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby start-rubyci && rm -rf tmp/build
     CRON
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,21 @@ node.reverse_merge!(
   },
 )
 
+# mitamae's git resource cannot update a repo whose HEAD was moved off the
+# deploy branch (e.g. by a manual `git checkout master`): the stale deploy
+# branch makes `git checkout <sha> -b deploy` fail. Drop it beforehand.
+%w[
+  /home/chkbuild/.rbenv
+  /home/chkbuild/.rbenv/plugins/ruby-build
+  /home/chkbuild/.rbenv/plugins/rbenv-default-gems
+].each do |repo|
+  execute "remove stale deploy branch in #{repo}" do
+    command "git -C #{repo} branch -D deploy"
+    user 'chkbuild'
+    only_if "test \"$(git -C #{repo} rev-parse --abbrev-ref HEAD)\" != deploy && git -C #{repo} rev-parse -q --verify refs/heads/deploy"
+  end
+end
+
 include_recipe 'rbenv::user'
 
 file "/home/chkbuild/.bash_profile" do


### PR DESCRIPTION
Set the chkbuild cron interval per host from the measured duration of one full build cycle on rubyci.org, so each host runs as often as it can without overlapping runs. Fast hosts move to 2h, `ppc64le`, `crossruby` and `freebsd15-arm` need 4h, and the rest keep the 3h default. The interval is configured with `attributes.chkbuild.schedule` in `hosts.yml`.

Applying this to every host surfaced latent problems, fixed here as well. mitamae 1.11 misparses the `<<~` heredoc in the crontab recipe. A stale `deploy` branch left by a manual checkout breaks the rbenv git resource. A failed download had installed a 0-byte mitamae on openbsd, turning every apply into a silent no-op. openbsd keeps its historical `openbsd-current` nickname, and ruby on FreeBSD 15 (pkgbase) needs `SSL_CERT_FILE` in the crontab.

Generated with [Claude Code](https://claude.com/claude-code)
