### PR TITLE
Restore per-host crontab command and env lost by the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The chkbuild user's crontab is installed only when AWS credentials are given via
 
 The cron interval defaults to every 3 hours and can be overridden per host with `attributes.chkbuild.schedule` in `hosts.yml`. The interval is sized from the measured duration of one full chkbuild cycle (all branches) on rubyci.org plus ~15 minutes of headroom, since chkbuild aborts when the previous run still holds its lock.
 
+The cron command runs `start-rubyci` by default and can be overridden per host with `attributes.chkbuild.command` (e.g. `start-cross-rubyci` on crossruby). Extra crontab environment lines can be added per host with the `attributes.chkbuild.env` mapping (e.g. `LC_ALL: C` and `DFLTCC: "0"` on s390x).
+
 ```bash
 CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho apply fedora44-arm.rubyci.org
 ```

--- a/hosts.yml
+++ b/hosts.yml
@@ -202,6 +202,11 @@ freebsd15-arm.rubyci.org:
   properties:
     attributes:
       chkbuild:
+        env:
+          # ruby built on FreeBSD 15 (pkgbase) does not find the system CA
+          # bundle by itself and every https access fails without this.
+          # Not needed on FreeBSD 14 and earlier.
+          SSL_CERT_FILE: /usr/local/share/certs/ca-root-nss.crt
         schedule: "30 */4 * * *"
     nopasswd_sudo: true
     compress: false

--- a/hosts.yml
+++ b/hosts.yml
@@ -79,6 +79,17 @@ ppc64le.rubyci.org: # power9
 
 s390x.rubyci.org: # z15
   properties:
+    attributes:
+      chkbuild:
+        env:
+          # /etc/default/locale sets LANG=en_US (ISO-8859-1) and cron picks it
+          # up via pam_env; encoding-sensitive tests expect a non-ISO-8859-1
+          # locale, so pin the historical LC_ALL=C.
+          LC_ALL: C
+          # Disable the s390x hardware deflate (DFLTCC) in Ubuntu's zlib;
+          # its output bytes differ from software zlib and break the
+          # byte-exact zlib tests/specs.
+          DFLTCC: "0"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -112,6 +123,10 @@ crossruby.rubyci.org:
   properties:
     attributes:
       chkbuild:
+        # This host builds cross-compilation targets (wasm, android, mingw,
+        # ...) with start-cross-rubyci; running the default start-rubyci
+        # would wrongly report plain ruby branches to rubyci.org.
+        command: start-cross-rubyci
         schedule: "30 */4 * * *"
     nopasswd_sudo: true
     compress: false

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -22,14 +22,8 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
     "AWS_SECRET_ACCESS_KEY=#{chkbuild[:aws_secret_access_key]}",
     "RUBYCI_NICKNAME=#{chkbuild[:nickname]}",
   ]
-  if node[:platform] == 'freebsd' && node[:platform_version].to_i >= 15
-    # ruby built on FreeBSD 15 (pkgbase) does not find the system CA bundle
-    # by itself and every https access fails without this. Not needed on
-    # FreeBSD 14 and earlier.
-    lines << 'SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt'
-  end
   # Extra per-host environment lines (attributes.chkbuild.env in hosts.yml),
-  # e.g. LC_ALL/DFLTCC on s390x.
+  # e.g. LC_ALL/DFLTCC on s390x, SSL_CERT_FILE on FreeBSD 15.
   (chkbuild[:env] || {}).each do |key, value|
     lines << "#{key}=#{value}"
   end

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -12,6 +12,10 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
   # still holds its lock, so an overlap loses a whole cycle.
   schedule = chkbuild[:schedule] || '30 */3 * * *'
 
+  # e.g. crossruby builds cross targets with start-cross-rubyci, not plain
+  # ruby branches with start-rubyci.
+  command = chkbuild[:command] || 'start-rubyci'
+
   lines = [
     'MAILTO=""',
     "AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}",
@@ -24,7 +28,12 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
     # FreeBSD 14 and earlier.
     lines << 'SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt'
   end
-  lines << "#{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby start-rubyci && rm -rf tmp/build"
+  # Extra per-host environment lines (attributes.chkbuild.env in hosts.yml),
+  # e.g. LC_ALL/DFLTCC on s390x.
+  (chkbuild[:env] || {}).each do |key, value|
+    lines << "#{key}=#{value}"
+  end
+  lines << "#{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
   lines << ''
 
   # NOTE: no <<~ heredoc here; the mruby in mitamae <= 1.11 misparses it as


### PR DESCRIPTION
The crontab template from #48 overwrote the hand-maintained crontabs and dropped their host-specific settings, which broke two hosts. `s390x` lost `LC_ALL=C` and `DFLTCC=0`, so the cron locale fell back to ISO-8859-1 via `pam_env` and the s390x hardware deflate (DFLTCC) broke the byte-exact zlib tests. `crossruby` must run `start-cross-rubyci` instead of `start-rubyci`, otherwise plain ruby branches get built and wrongly reported to rubyci.org. This adds `attributes.chkbuild.command` and `attributes.chkbuild.env` overrides to `hosts.yml` and moves the FreeBSD 15 `SSL_CERT_FILE` special case onto the same mechanism. Both hosts were re-applied and the installed crontabs verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
