### PR TITLE
Restore the no-yjit builds on the ubuntu hosts

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -55,6 +55,16 @@ openbsd.rubyci.org:
 
 ubuntu.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        # The primary build runs at :10 and the no-yjit checkout at :30 as
+        # the hand-maintained crontab historically did; each checkout has
+        # its own lock, so the runs may overlap safely.
+        schedule: "10 */3 * * *"
+        extra_builds:
+          - dir: chkbuild-no-yjit
+            nickname: ubuntu-no-yjit
+            schedule: "30 */3 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -166,6 +176,13 @@ freebsd14.rubyci.org:
 
 ubuntu-arm.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        schedule: "10 */3 * * *"
+        extra_builds:
+          - dir: chkbuild-no-yjit
+            nickname: ubuntu-arm-no-yjit
+            schedule: "30 */3 * * *"
     nopasswd_sudo: true
     compress: false
     run_list:

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -28,6 +28,13 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
     lines << "#{key}=#{value}"
   end
   lines << "#{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
+  # Additional chkbuild checkouts on the same host
+  # (attributes.chkbuild.extra_builds in hosts.yml), e.g. ~/chkbuild-no-yjit
+  # reporting as ubuntu-no-yjit. RUBYCI_NICKNAME is overridden per line
+  # because the global assignment above names the primary build.
+  (chkbuild[:extra_builds] || []).each do |extra|
+    lines << "#{extra[:schedule]} cd ~/#{extra[:dir]} && git pull origin master && RUBYCI_NICKNAME=#{extra[:nickname]} ~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
+  end
   lines << ''
 
   # NOTE: no <<~ heredoc here; the mruby in mitamae <= 1.11 misparses it as


### PR DESCRIPTION
The crontab template from #48 overwrote the hand-maintained crontabs on `ubuntu` and `ubuntu-arm` and dropped their second cron line, so the `ubuntu-no-yjit` and `ubuntu-arm-no-yjit` reports on rubyci.org stopped on Jul 24. Both hosts build a separate `~/chkbuild-no-yjit` checkout whose cron line overrides `RUBYCI_NICKNAME`. This adds `attributes.chkbuild.extra_builds` so additional chkbuild checkouts on one host get their own cron line with a per-line `RUBYCI_NICKNAME`, and restores the historical schedule with the primary build at :10 and the no-yjit build at :30 every 3 hours. The generated crontabs match the pre-#48 crontabs recovered from the CRON lines in syslog.

Generated with [Claude Code](https://claude.com/claude-code)
