### PR TITLE
Restore the icc-x64 nickname and Intel oneAPI paths on icc

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -21,6 +21,18 @@ arch.rubyci.org:
 
 icc.rubyci.org:
   properties:
+    attributes:
+      chkbuild:
+        # Reports to rubyci.org as icc-x64; chkbuild's start-rubyci switches
+        # CC/CXX to the Intel compiler (icx) only for this nickname, and the
+        # S3 logs live under the icc-x64/ prefix.
+        nickname: icc-x64
+        env:
+          # icx is not on the cron default PATH and the oneAPI runtime
+          # libraries (libimf, libsvml, ...) are not in ld.so.conf, so both
+          # the compiler and the ruby binaries it builds need these.
+          PATH: /opt/intel/oneapi/compiler/latest/bin:/usr/local/bin:/usr/bin:/bin
+          LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/lib
     nopasswd_sudo: true
     compress: false
     run_list:


### PR DESCRIPTION
The recipe-generated crontab derived `RUBYCI_NICKNAME=icc` from the host name, but chkbuild's `start-rubyci` switches to the Intel compiler only for the `icc-x64` nickname, so the host silently built with gcc and uploaded to the wrong `icc/` S3 prefix while rubyci.org kept watching `icc-x64/`. The oneAPI `PATH` and `LD_LIBRARY_PATH` from the hand-maintained crontab were also lost. `icx` is not on the cron default `PATH` and its runtime libraries are not in `ld.so.conf`, so both are restored as chkbuild env attributes. Verified on the host that a run under the new crontab environment configures with `icx -std=gnu99` and reports as `icc-x64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
