### PR TITLE
Restore inline build env in the crossruby crontab

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mswin64
 
 DEPENDENCIES
   bcrypt_pbkdf

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The chkbuild user's crontab is installed only when AWS credentials are given via
 
 The cron interval defaults to every 3 hours and can be overridden per host with `attributes.chkbuild.schedule` in `hosts.yml`. The interval is sized from the measured duration of one full chkbuild cycle (all branches) on rubyci.org plus ~15 minutes of headroom, since chkbuild aborts when the previous run still holds its lock.
 
-The cron command runs `start-rubyci` by default and can be overridden per host with `attributes.chkbuild.command` (e.g. `start-cross-rubyci` on crossruby). Extra crontab environment lines can be added per host with the `attributes.chkbuild.env` mapping (e.g. `LC_ALL: C` and `DFLTCC: "0"` on s390x).
+The cron command runs `start-rubyci` by default and can be overridden per host with `attributes.chkbuild.command` (e.g. `start-cross-rubyci` on crossruby). Extra crontab environment lines can be added per host with the `attributes.chkbuild.env` mapping (e.g. `LC_ALL: C` and `DFLTCC: "0"` on s390x). Environment that needs shell expansion goes in the `attributes.chkbuild.command_env` mapping instead, which is prepended inline to the build command (e.g. the android NDK `PATH` prefix and `WASI_SDK_PATH` on crossruby); cron takes crontab environment lines literally and would not expand `$PATH`.
 
 ```bash
 CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho apply fedora44-arm.rubyci.org

--- a/hosts.yml
+++ b/hosts.yml
@@ -138,6 +138,13 @@ crossruby.rubyci.org:
         # would wrongly report plain ruby branches to rubyci.org.
         command: start-cross-rubyci
         schedule: "30 */4 * * *"
+        # The wasm targets need the WASI SDK and the android targets need the
+        # NDK toolchain in PATH; without the NDK clang the android builds
+        # fail. $PATH must be expanded by the shell, so these are inline
+        # command_env, not crontab env lines.
+        command_env:
+          WASI_SDK_PATH: /home/chkbuild/opt/wasi-sdk-25.0-x86_64-linux
+          PATH: "/home/chkbuild/opt/android-ndk-r28b/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
     nopasswd_sudo: true
     compress: false
     run_list:

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -16,6 +16,13 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
   # ruby branches with start-rubyci.
   command = chkbuild[:command] || 'start-rubyci'
 
+  # Inline environment prepended to the build command
+  # (attributes.chkbuild.command_env in hosts.yml), e.g. the android NDK
+  # PATH prefix on crossruby. Unlike env above these go on the command line
+  # because cron takes crontab environment lines literally; values that
+  # reference $PATH need the shell expansion they get here.
+  command_prefix = (chkbuild[:command_env] || {}).map {|key, value| "#{key}=#{value} " }.join
+
   lines = [
     'MAILTO=""',
     "AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}",
@@ -27,13 +34,13 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
   (chkbuild[:env] || {}).each do |key, value|
     lines << "#{key}=#{value}"
   end
-  lines << "#{schedule} cd ~/chkbuild && git pull origin master && ~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
+  lines << "#{schedule} cd ~/chkbuild && git pull origin master && #{command_prefix}~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
   # Additional chkbuild checkouts on the same host
   # (attributes.chkbuild.extra_builds in hosts.yml), e.g. ~/chkbuild-no-yjit
   # reporting as ubuntu-no-yjit. RUBYCI_NICKNAME is overridden per line
   # because the global assignment above names the primary build.
   (chkbuild[:extra_builds] || []).each do |extra|
-    lines << "#{extra[:schedule]} cd ~/#{extra[:dir]} && git pull origin master && RUBYCI_NICKNAME=#{extra[:nickname]} ~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
+    lines << "#{extra[:schedule]} cd ~/#{extra[:dir]} && git pull origin master && RUBYCI_NICKNAME=#{extra[:nickname]} #{command_prefix}~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
   end
   lines << ''
 


### PR DESCRIPTION
The crontab recipe migration dropped the inline environment the hand-maintained crossruby crontab put before the build command, so the android cross builds lost the NDK clang and stopped. The pre-migration syslog CRON history shows `WASI_SDK_PATH=... PATH=<ndk bin>:$PATH ~/.rbenv/shims/ruby start-cross-rubyci`.

This adds an `attributes.chkbuild.command_env` mapping rendered inline before the build command and sets `WASI_SDK_PATH` and the android NDK `PATH` prefix on crossruby. These cannot use the existing `chkbuild.env` crontab environment lines because cron takes those literally and never expands `$PATH`. The rendered cron line matches the pre-migration syslog `CMD` byte for byte. The host crontab has already been repaired in place with the same content.

Generated with [Claude Code](https://claude.com/claude-code)
