### PR TITLE
Add intel-oneapi recipe for icc.rubyci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho appl
 
 ### Intel oneAPI (icc.rubyci.org)
 
-`recipes/intel-oneapi.rb` sets up Intel's apt repository and installs `intel-basekit` and `intel-hpckit`, which provide the `icx` compiler chkbuild uses on this host. The crontab environment that switches the build to icx (`PATH`, `LD_LIBRARY_PATH`) is defined in `attributes.chkbuild.env` in `hosts.yml`.
+`recipes/intel-oneapi.rb` sets up Intel's apt repository and installs `intel-basekit`, which provides the `icx` compiler chkbuild uses on this host. The crontab environment that switches the build to icx (`PATH`, `LD_LIBRARY_PATH`) is defined in `attributes.chkbuild.env` in `hosts.yml`.
 
 ### All chkbuild
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ The cron command runs `start-rubyci` by default and can be overridden per host w
 CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho apply fedora44-arm.rubyci.org
 ```
 
+### Intel oneAPI (icc.rubyci.org)
+
+`recipes/intel-oneapi.rb` sets up Intel's apt repository and installs `intel-basekit` and `intel-hpckit`, which provide the `icx` compiler chkbuild uses on this host. The crontab environment that switches the build to icx (`PATH`, `LD_LIBRARY_PATH`) is defined in `attributes.chkbuild.env` in `hosts.yml`.
+
 ### All chkbuild
 
 `bin/all-hosts` runs a command for every host in `hosts.yml` in parallel, appending the host name as the last argument. Full per-host output goes to `$TMPDIR/all-hosts-<timestamp>/<host>.log` and a summary is printed at the end. Use `-j N` to limit concurrency.

--- a/hosts.yml
+++ b/hosts.yml
@@ -36,6 +36,9 @@ icc.rubyci.org:
     nopasswd_sudo: true
     compress: false
     run_list:
+      # intel-oneapi.rb runs first so the compiler exists before default.rb
+      # can install the chkbuild crontab that depends on it.
+      - recipes/intel-oneapi.rb
       - recipes/default.rb
 
 rhel8.rubyci.org:

--- a/recipes/intel-oneapi.rb
+++ b/recipes/intel-oneapi.rb
@@ -1,0 +1,31 @@
+# Intel oneAPI toolkits for icc.rubyci.org. chkbuild builds ruby with icx
+# (see attributes.chkbuild in hosts.yml: RUBYCI_NICKNAME=icc-x64 plus the
+# PATH/LD_LIBRARY_PATH pointing into /opt/intel/oneapi). The compiler comes
+# from Intel's apt repository, not Ubuntu; intel-basekit provides icx/icpx
+# and intel-hpckit adds ifx and MPI, matching what was installed by hand on
+# the current host. The /opt/intel/oneapi/compiler/latest symlink referenced
+# by the crontab is maintained by the packages themselves.
+
+keyring = '/usr/share/keyrings/oneapi-archive-keyring.gpg'
+
+package 'gnupg'
+
+execute 'download Intel oneAPI apt keyring' do
+  command "curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor -o #{keyring}"
+  not_if "test -s #{keyring}"
+end
+
+file '/etc/apt/sources.list.d/oneAPI.list' do
+  owner 'root'
+  mode '644'
+  content "deb [signed-by=#{keyring}] https://apt.repos.intel.com/oneapi all main\n"
+end
+
+# Refresh the package index only while the Intel repo is still unknown to
+# apt; regular index updates are handled by bin/os-update.
+execute 'apt-get update' do
+  not_if 'apt-cache policy | grep -q apt.repos.intel.com'
+end
+
+package 'intel-basekit'
+package 'intel-hpckit'

--- a/recipes/intel-oneapi.rb
+++ b/recipes/intel-oneapi.rb
@@ -1,10 +1,10 @@
-# Intel oneAPI toolkits for icc.rubyci.org. chkbuild builds ruby with icx
+# Intel oneAPI toolkit for icc.rubyci.org. chkbuild builds ruby with icx
 # (see attributes.chkbuild in hosts.yml: RUBYCI_NICKNAME=icc-x64 plus the
 # PATH/LD_LIBRARY_PATH pointing into /opt/intel/oneapi). The compiler comes
-# from Intel's apt repository, not Ubuntu; intel-basekit provides icx/icpx
-# and intel-hpckit adds ifx and MPI, matching what was installed by hand on
-# the current host. The /opt/intel/oneapi/compiler/latest symlink referenced
-# by the crontab is maintained by the packages themselves.
+# from Intel's apt repository, not Ubuntu; icx/icpx and their runtime
+# (libimf, libsvml, ...) come from intel-oneapi-compiler-dpcpp-cpp, pulled
+# in by intel-basekit. The /opt/intel/oneapi/compiler/latest symlink
+# referenced by the crontab is maintained by the packages themselves.
 
 keyring = '/usr/share/keyrings/oneapi-archive-keyring.gpg'
 
@@ -28,4 +28,3 @@ execute 'apt-get update' do
 end
 
 package 'intel-basekit'
-package 'intel-hpckit'


### PR DESCRIPTION
icc.rubyci.org had the `icx` compiler installed by hand and only the chkbuild crontab was under recipe control. `recipes/intel-oneapi.rb` reproduces that state so the host can be rebuilt with hocho alone. It sets up Intel's apt keyring and repository and installs `intel-basekit`, which pulls `icx` and its runtime via `intel-oneapi-compiler-dpcpp-cpp`. `intel-hpckit` was also installed on the host but only adds `ifx` and MPI, which ruby builds never use, so it is not reproduced and has been removed from the host. The recipe runs before `recipes/default.rb` in the icc run_list so the compiler exists before the chkbuild crontab goes live. `mitamae --dry-run` on the live host reports no changes.
