### PR TITLE
Manage the crossruby host with mitamae

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho appl
 
 ### crossruby toolchains
 
-When `attributes.chkbuild.command` is `start-cross-rubyci`, `recipes/crossruby.rb` installs the cross toolchains on top of the common setup: the Ubuntu cross gcc packages for the linux/mingw targets, emscripten, and the WASI SDK and Android NDK under `/home/chkbuild/opt`. The WASI SDK and NDK versions are pinned in the recipe and must match the `WASI_SDK_PATH` and NDK `PATH` prefix in `attributes.chkbuild.command_env` in `hosts.yml`.
+When `attributes.chkbuild.command` is `start-cross-rubyci`, `recipes/crossruby.rb` installs the cross toolchains on top of the common setup: the Ubuntu cross gcc packages for the linux/mingw targets, emscripten, and the WASI SDK and Android NDK under `/home/chkbuild/opt`. The WASI SDK and NDK versions are resolved to the latest stable GitHub release at every apply, and the version-independent symlinks `/home/chkbuild/opt/wasi-sdk` and `/home/chkbuild/opt/android-ndk` are pointed at them, so the crontab paths in `attributes.chkbuild.command_env` never change. Superseded toolchain versions are removed, except directories still referenced by the installed crontab (an apply without AWS credentials leaves the crontab untouched, and its toolchains must survive until the next apply with credentials).
 
 ### All chkbuild
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho appl
 
 `recipes/intel-oneapi.rb` sets up Intel's apt repository and installs `intel-basekit`, which provides the `icx` compiler chkbuild uses on this host. The crontab environment that switches the build to icx (`PATH`, `LD_LIBRARY_PATH`) is defined in `attributes.chkbuild.env` in `hosts.yml`.
 
+### crossruby toolchains
+
+When `attributes.chkbuild.command` is `start-cross-rubyci`, `recipes/crossruby.rb` installs the cross toolchains on top of the common setup: the Ubuntu cross gcc packages for the linux/mingw targets, emscripten, and the WASI SDK and Android NDK under `/home/chkbuild/opt`. The WASI SDK and NDK versions are pinned in the recipe and must match the `WASI_SDK_PATH` and NDK `PATH` prefix in `attributes.chkbuild.command_env` in `hosts.yml`.
+
 ### All chkbuild
 
 `bin/all-hosts` runs a command for every host in `hosts.yml` in parallel, appending the host name as the last argument. Full per-host output goes to `$TMPDIR/all-hosts-<timestamp>/<host>.log` and a summary is printed at the end. Use `-j N` to limit concurrency.

--- a/hosts.yml
+++ b/hosts.yml
@@ -156,7 +156,9 @@ crossruby.rubyci.org:
         # The wasm targets need the WASI SDK and the android targets need the
         # NDK toolchain in PATH; without the NDK clang the android builds
         # fail. $PATH must be expanded by the shell, so these are inline
-        # command_env, not crontab env lines.
+        # command_env, not crontab env lines. Both toolchains are installed
+        # by recipes/crossruby.rb; keep these paths in sync with the versions
+        # pinned there.
         command_env:
           WASI_SDK_PATH: /home/chkbuild/opt/wasi-sdk-25.0-x86_64-linux
           PATH: "/home/chkbuild/opt/android-ndk-r28b/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"

--- a/hosts.yml
+++ b/hosts.yml
@@ -156,12 +156,12 @@ crossruby.rubyci.org:
         # The wasm targets need the WASI SDK and the android targets need the
         # NDK toolchain in PATH; without the NDK clang the android builds
         # fail. $PATH must be expanded by the shell, so these are inline
-        # command_env, not crontab env lines. Both toolchains are installed
-        # by recipes/crossruby.rb; keep these paths in sync with the versions
-        # pinned there.
+        # command_env, not crontab env lines. recipes/crossruby.rb installs
+        # the latest stable toolchains and points these version-independent
+        # symlinks at them, so version bumps need no change here.
         command_env:
-          WASI_SDK_PATH: /home/chkbuild/opt/wasi-sdk-25.0-x86_64-linux
-          PATH: "/home/chkbuild/opt/android-ndk-r28b/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+          WASI_SDK_PATH: /home/chkbuild/opt/wasi-sdk
+          PATH: "/home/chkbuild/opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
     nopasswd_sudo: true
     compress: false
     run_list:

--- a/recipes/crossruby.rb
+++ b/recipes/crossruby.rb
@@ -33,15 +33,6 @@ package 'bison'
 
 package 'unzip' # to extract the android NDK zip below
 
-node.reverse_merge!(
-  crossruby: {
-    # Also referenced from attributes.chkbuild.command_env in hosts.yml
-    # (WASI_SDK_PATH and the android NDK PATH prefix); keep them in sync.
-    wasi_sdk_version: '25.0',
-    android_ndk_version: 'r28b',
-  },
-)
-
 opt = '/home/chkbuild/opt'
 
 directory opt do
@@ -49,12 +40,27 @@ directory opt do
   mode '755'
 end
 
-wasi_sdk_version = node[:crossruby][:wasi_sdk_version]
-wasi_sdk_dir = "wasi-sdk-#{wasi_sdk_version}-x86_64-linux"
-wasi_sdk_tag = "wasi-sdk-#{wasi_sdk_version.split('.').first}"
-wasi_sdk_url = "https://github.com/WebAssembly/wasi-sdk/releases/download/#{wasi_sdk_tag}/#{wasi_sdk_dir}.tar.gz"
+# Resolve the latest stable releases at apply time so every hocho apply
+# rolls the toolchains forward. The crontab in hosts.yml references the
+# version-independent wasi-sdk/android-ndk symlinks below, so a version
+# bump needs no crontab update. mitamae has no run_command in the recipe
+# context; the backticks come from mruby-io and run on the host.
+wasi_api = `curl -fsSL --max-time 30 https://api.github.com/repos/WebAssembly/wasi-sdk/releases/latest`
+unless wasi_api =~ %r{"browser_download_url": *"(https://[^"]+/(wasi-sdk-[0-9.]+-x86_64-linux))\.tar\.gz"}
+  raise 'cannot resolve the latest wasi-sdk release from the GitHub API'
+end
+wasi_sdk_url = "#{$1}.tar.gz"
+wasi_sdk_dir = $2
 
-# The trailing test fails the run when the tarball was truncated; a later
+ndk_api = `curl -fsSL --max-time 30 https://api.github.com/repos/android/ndk/releases/latest`
+unless ndk_api =~ /"tag_name": *"(r[0-9]+[a-z]*)"/
+  raise 'cannot resolve the latest android NDK release from the GitHub API'
+end
+android_ndk_dir = "android-ndk-#{$1}"
+android_ndk_url = "https://dl.google.com/android/repository/#{android_ndk_dir}-linux.zip"
+android_ndk_clang = "#{android_ndk_dir}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang"
+
+# The trailing test fails the run when the download was truncated; a later
 # run then re-extracts over the partial tree.
 execute "install #{wasi_sdk_dir}" do
   command "cd #{opt} && curl -fsSL #{wasi_sdk_url} | tar -xz && test -x #{wasi_sdk_dir}/bin/clang"
@@ -62,13 +68,29 @@ execute "install #{wasi_sdk_dir}" do
   not_if "test -x #{opt}/#{wasi_sdk_dir}/bin/clang"
 end
 
-android_ndk_version = node[:crossruby][:android_ndk_version]
-android_ndk_dir = "android-ndk-#{android_ndk_version}"
-android_ndk_url = "https://dl.google.com/android/repository/#{android_ndk_dir}-linux.zip"
-android_ndk_clang = "#{android_ndk_dir}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang"
+link "#{opt}/wasi-sdk" do
+  to "#{opt}/#{wasi_sdk_dir}"
+  force true
+end
 
 execute "install #{android_ndk_dir}" do
   command "cd #{opt} && curl -fsSLo #{android_ndk_dir}-linux.zip #{android_ndk_url} && unzip -oq #{android_ndk_dir}-linux.zip && rm #{android_ndk_dir}-linux.zip && test -x #{android_ndk_clang}"
   user 'chkbuild'
   not_if "test -x #{opt}/#{android_ndk_clang}"
+end
+
+link "#{opt}/android-ndk" do
+  to "#{opt}/#{android_ndk_dir}"
+  force true
+end
+
+# Drop superseded toolchain versions and the manual download leftovers.
+# A directory still referenced by the installed crontab is kept: without
+# AWS credentials at apply time the crontab keeps its previous paths (see
+# chkbuild-cron.rb) and the running builds must not lose their toolchain.
+keep_current = %Q{[ "$d" = #{wasi_sdk_dir} ] && continue; [ "$d" = #{android_ndk_dir} ] && continue; grep -qF "opt/$d" /home/chkbuild/.crontab 2>/dev/null && continue}
+
+execute 'remove old wasi-sdk/android-ndk versions' do
+  command %Q{cd #{opt} && for d in wasi-sdk-[0-9]* android-ndk-r*; do [ -e "$d" ] || continue; #{keep_current}; rm -rf "$d"; done && rm -f /home/chkbuild/wasi-sdk-*.tar.gz}
+  only_if %Q{cd #{opt} && { for d in wasi-sdk-[0-9]* android-ndk-r*; do [ -e "$d" ] || continue; #{keep_current}; echo "$d"; done; ls /home/chkbuild/wasi-sdk-*.tar.gz 2>/dev/null; } | grep -q .}
 end

--- a/recipes/crossruby.rb
+++ b/recipes/crossruby.rb
@@ -1,0 +1,74 @@
+# Cross-compilation toolchains for the crossruby host. Included from
+# default.rb only when attributes.chkbuild.command is start-cross-rubyci,
+# i.e. the host builds cross targets instead of plain ruby branches.
+# The host is Ubuntu; no other platform is supported here.
+
+# start-cross-rubyci probes each cross compiler with Util.search_command and
+# skips targets whose compiler is missing, so this list is what makes the
+# linux/mingw targets actually build. mips (big-endian) and s390 are also
+# defined there but Ubuntu ships no compiler for them.
+%w[
+  gcc-mingw-w64-i686
+  gcc-mingw-w64-x86-64
+  gcc-arm-linux-gnueabi
+  gcc-mipsel-linux-gnu
+  gcc-powerpc-linux-gnu
+  gcc-sparc64-linux-gnu
+  gcc-aarch64-linux-gnu
+  gcc-hppa-linux-gnu
+  gcc-m68k-linux-gnu
+].each do |pkg|
+  package pkg
+end
+
+# wasm32/64-emscripten targets build with Ubuntu's emcc; nodejs comes in as
+# a dependency. The wasm32-wasi and android targets use the toolchains
+# installed under /home/chkbuild/opt below.
+package 'emscripten'
+
+# Every build runs ./autogen.sh from a git checkout; the rbenv dependency
+# recipe covers the rest of the ruby build dependencies but not these two.
+package 'autoconf'
+package 'bison'
+
+package 'unzip' # to extract the android NDK zip below
+
+node.reverse_merge!(
+  crossruby: {
+    # Also referenced from attributes.chkbuild.command_env in hosts.yml
+    # (WASI_SDK_PATH and the android NDK PATH prefix); keep them in sync.
+    wasi_sdk_version: '25.0',
+    android_ndk_version: 'r28b',
+  },
+)
+
+opt = '/home/chkbuild/opt'
+
+directory opt do
+  owner 'chkbuild'
+  mode '755'
+end
+
+wasi_sdk_version = node[:crossruby][:wasi_sdk_version]
+wasi_sdk_dir = "wasi-sdk-#{wasi_sdk_version}-x86_64-linux"
+wasi_sdk_tag = "wasi-sdk-#{wasi_sdk_version.split('.').first}"
+wasi_sdk_url = "https://github.com/WebAssembly/wasi-sdk/releases/download/#{wasi_sdk_tag}/#{wasi_sdk_dir}.tar.gz"
+
+# The trailing test fails the run when the tarball was truncated; a later
+# run then re-extracts over the partial tree.
+execute "install #{wasi_sdk_dir}" do
+  command "cd #{opt} && curl -fsSL #{wasi_sdk_url} | tar -xz && test -x #{wasi_sdk_dir}/bin/clang"
+  user 'chkbuild'
+  not_if "test -x #{opt}/#{wasi_sdk_dir}/bin/clang"
+end
+
+android_ndk_version = node[:crossruby][:android_ndk_version]
+android_ndk_dir = "android-ndk-#{android_ndk_version}"
+android_ndk_url = "https://dl.google.com/android/repository/#{android_ndk_dir}-linux.zip"
+android_ndk_clang = "#{android_ndk_dir}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang"
+
+execute "install #{android_ndk_dir}" do
+  command "cd #{opt} && curl -fsSLo #{android_ndk_dir}-linux.zip #{android_ndk_url} && unzip -oq #{android_ndk_dir}-linux.zip && rm #{android_ndk_dir}-linux.zip && test -x #{android_ndk_clang}"
+  user 'chkbuild'
+  not_if "test -x #{opt}/#{android_ndk_clang}"
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -100,4 +100,10 @@ when 'gentoo'
   end
 end
 
+# The host running start-cross-rubyci needs the cross toolchains (cross gcc,
+# emscripten, WASI SDK, android NDK) on top of the common setup above.
+if (node[:chkbuild] || {})[:command] == 'start-cross-rubyci'
+  include_recipe "crossruby"
+end
+
 include_recipe "chkbuild-cron"


### PR DESCRIPTION
The crossruby host was built by hand and only its crontab was under IaC. `recipes/crossruby.rb`, included when `attributes.chkbuild.command` is `start-cross-rubyci`, now installs the cross gcc packages, emscripten, the WASI SDK and the Android NDK.

The WASI SDK and NDK versions are resolved to the latest stable GitHub release at every apply, and the version-independent symlinks `/home/chkbuild/opt/wasi-sdk` and `/home/chkbuild/opt/android-ndk` point at them, so the crontab in `hosts.yml` never names a version. Superseded versions are removed, except directories the installed crontab still references, which keeps a credential-less apply from breaking running builds.

I verified the recipe on the host with `mitamae local`. The first run installed wasi-sdk 33.0 and NDK r29 and removed the old leftovers. A second run is a no-op.

Generated with [Claude Code](https://claude.com/claude-code)
