### PR TITLE
Authenticate chkbuild S3 uploads with EC2 instance profiles

### DIFF
--- a/hocho.yml
+++ b/hocho.yml
@@ -2,8 +2,11 @@ property_providers:
   - add_default:
       properties:
         preferred_driver: mitamae
-  # Derive RUBYCI_NICKNAME from the host name and inject AWS credentials
-  # for the chkbuild crontab from environment variables at apply time.
+  # Derive RUBYCI_NICKNAME from the host name for the chkbuild crontab.
+  # S3 upload credentials come from the default credential chain on each
+  # host: EC2 hosts use their instance profile, and the few non-EC2 hosts
+  # (attributes.chkbuild.aws_credentials_file in hosts.yml) get
+  # ~/.aws/credentials written from environment variables at apply time.
   - ruby_script:
       script: |
         return unless host.name.end_with?('.rubyci.org')
@@ -15,7 +18,8 @@ property_providers:
         # e.g. openbsd reports to rubyci as openbsd-current; keep an explicit
         # nickname from hosts.yml over the host-name-derived one.
         chkbuild[:nickname] ||= host.name.split('.').first
-        if ENV['CHKBUILD_AWS_ACCESS_KEY_ID'] && ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']
+        if chkbuild[:aws_credentials_file] &&
+           ENV['CHKBUILD_AWS_ACCESS_KEY_ID'] && ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']
           chkbuild[:aws_access_key_id] = ENV['CHKBUILD_AWS_ACCESS_KEY_ID']
           chkbuild[:aws_secret_access_key] = ENV['CHKBUILD_AWS_SECRET_ACCESS_KEY']
         end

--- a/hosts.yml
+++ b/hosts.yml
@@ -97,6 +97,9 @@ ppc64le.rubyci.org: # power9
     attributes:
       chkbuild:
         schedule: "30 */4 * * *"
+        # Not an EC2 instance (OSU Open Source Lab), so no instance profile;
+        # S3 upload credentials live in ~/.aws/credentials instead.
+        aws_credentials_file: true
     nopasswd_sudo: true
     compress: false
     run_list:
@@ -106,6 +109,9 @@ s390x.rubyci.org: # z15
   properties:
     attributes:
       chkbuild:
+        # Not an EC2 instance (IBM LinuxONE), so no instance profile;
+        # S3 upload credentials live in ~/.aws/credentials instead.
+        aws_credentials_file: true
         env:
           # /etc/default/locale sets LANG=en_US (ISO-8859-1) and cron picks it
           # up via pam_env; encoding-sensitive tests expect a non-ISO-8859-1

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -1,10 +1,34 @@
-# Install the chkbuild user's crontab. AWS credentials are injected into
-# node[:chkbuild] by the ruby_script property provider in hocho.yml only
-# when CHKBUILD_AWS_ACCESS_KEY_ID/CHKBUILD_AWS_SECRET_ACCESS_KEY are set
-# at apply time; otherwise the crontab is left untouched.
+# Install the chkbuild user's crontab. S3 uploads authenticate via the
+# default credential chain (EC2 instance profile, or ~/.aws/credentials on
+# non-EC2 hosts), so the crontab carries no AWS keys. node[:chkbuild] is
+# populated by the ruby_script property provider in hocho.yml only for
+# *.rubyci.org hosts; elsewhere the crontab is left untouched.
 chkbuild = node[:chkbuild] || {}
 
-if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
+if chkbuild[:nickname]
+  # Non-EC2 hosts (aws_credentials_file in hosts.yml) cannot use an
+  # instance profile, so they keep a long-lived key in ~/.aws/credentials.
+  # The key pair reaches node[:chkbuild] only when CHKBUILD_AWS_* are set
+  # at apply time; a credential-less apply skips this and leaves the
+  # existing file untouched.
+  if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
+    directory "/home/chkbuild/.aws" do
+      owner 'chkbuild'
+      mode '700'
+    end
+
+    file "/home/chkbuild/.aws/credentials" do
+      owner 'chkbuild'
+      mode '600'
+      content [
+        '[default]',
+        "aws_access_key_id = #{chkbuild[:aws_access_key_id]}",
+        "aws_secret_access_key = #{chkbuild[:aws_secret_access_key]}",
+        '',
+      ].join("\n")
+    end
+  end
+
   crontab_path = "/home/chkbuild/.crontab"
 
   # Interval per host is chosen so that one full chkbuild cycle (all branches)
@@ -25,8 +49,6 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
 
   lines = [
     'MAILTO=""',
-    "AWS_ACCESS_KEY_ID=#{chkbuild[:aws_access_key_id]}",
-    "AWS_SECRET_ACCESS_KEY=#{chkbuild[:aws_secret_access_key]}",
     "RUBYCI_NICKNAME=#{chkbuild[:nickname]}",
   ]
   # Extra per-host environment lines (attributes.chkbuild.env in hosts.yml),
@@ -56,5 +78,5 @@ if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
     not_if "crontab -l -u chkbuild 2>/dev/null | cmp -s - #{crontab_path}"
   end
 else
-  MItamae.logger.info "skipping chkbuild crontab (no AWS credentials given)"
+  MItamae.logger.info "skipping chkbuild crontab (not a rubyci host)"
 end


### PR DESCRIPTION
The chkbuild crontab carried a shared long-lived AWS key in plain text on every host. EC2 hosts now authenticate S3 uploads through the `chkbuild-uploader` instance profile via the SDK default credential chain, so neither the crontab nor the apply-time environment carries credentials for them.

The two non-EC2 hosts (`ppc64le`, `s390x`) cannot use an instance profile, so they are flagged with `aws_credentials_file` in `hosts.yml` and get `~/.aws/credentials` written only when `CHKBUILD_AWS_ACCESS_KEY_ID` and `CHKBUILD_AWS_SECRET_ACCESS_KEY` are set at apply time. A credential-less apply leaves the file untouched. The crontab guard now keys on the derived nickname instead of credential presence, which keeps non-rubyci hosts from getting a crontab.
