### PR TITLE
Manage the macOS hosts with mitamae

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ CHKBUILD_AWS_ACCESS_KEY_ID=... CHKBUILD_AWS_SECRET_ACCESS_KEY=... bin/hocho appl
 
 When `attributes.chkbuild.command` is `start-cross-rubyci`, `recipes/crossruby.rb` installs the cross toolchains on top of the common setup: the Ubuntu cross gcc packages for the linux/mingw targets, emscripten, and the WASI SDK and Android NDK under `/home/chkbuild/opt`. The WASI SDK and NDK versions are resolved to the latest stable GitHub release at every apply, and the version-independent symlinks `/home/chkbuild/opt/wasi-sdk` and `/home/chkbuild/opt/android-ndk` are pointed at them, so the crontab paths in `attributes.chkbuild.command_env` never change. Superseded toolchain versions are removed, except directories still referenced by the installed crontab (an apply without AWS credentials leaves the crontab untouched, and its toolchains must survive until the next apply with credentials).
 
+### macOS hosts (fuji, ringo)
+
+The macOS hosts are addressed by the ssh aliases `fuji` and `ringo` from `~/.ssh/config`, not by rubyci.org names. Everything runs as the hsbt login user; there is no chkbuild user. `recipes/macos.rb` manages the MacPorts build dependencies, rbenv with aws-sdk-s3 as a default gem, the chkbuild checkouts under `~/Documents` and the crontab. OS provisioning, Xcode Command Line Tools and the MacPorts installer itself are out of scope. sudo must be passwordless, via a drop-in in `/private/etc/sudoers.d` (the file name must not contain a period). With that in place `bin/hocho apply fuji` works like any other host.
+
 ### All chkbuild
 
 `bin/all-hosts` runs a command for every host in `hosts.yml` in parallel, appending the host name as the last argument. Full per-host output goes to `$TMPDIR/all-hosts-<timestamp>/<host>.log` and a summary is printed at the end. Use `-j N` to limit concurrency.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ When `attributes.chkbuild.command` is `start-cross-rubyci`, `recipes/crossruby.r
 
 ### macOS hosts (fuji, ringo)
 
-The macOS hosts are addressed by the ssh aliases `fuji` and `ringo` from `~/.ssh/config`, not by rubyci.org names. Everything runs as the hsbt login user; there is no chkbuild user. `recipes/macos.rb` manages the MacPorts build dependencies, rbenv with aws-sdk-s3 as a default gem, the chkbuild checkouts under `~/Documents` and the crontab. OS provisioning, Xcode Command Line Tools and the MacPorts installer itself are out of scope. sudo must be passwordless, via a drop-in in `/private/etc/sudoers.d` (the file name must not contain a period). With that in place `bin/hocho apply fuji` works like any other host.
+The macOS hosts are addressed by the ssh aliases `fuji` and `ringo` from `~/.ssh/config`, not by rubyci.org names. Everything runs as the pre-existing user named by `attributes.chkbuild.user` in `hosts.yml`, currently the hsbt login user. `recipes/macos.rb` manages the MacPorts build dependencies, rbenv with aws-sdk-s3 as a default gem, the chkbuild checkouts under `~/Documents` and the crontab. OS provisioning, Xcode Command Line Tools and the MacPorts installer itself are out of scope. sudo must be passwordless, via a drop-in in `/private/etc/sudoers.d` (the file name must not contain a period). With that in place `bin/hocho apply fuji` works like any other host.
 
 ### All chkbuild
 

--- a/hocho.yml
+++ b/hocho.yml
@@ -9,12 +9,15 @@ property_providers:
   # ~/.aws/credentials written from environment variables at apply time.
   - ruby_script:
       script: |
-        return unless host.name.end_with?('.rubyci.org')
         # Keep per-host chkbuild attributes from hosts.yml (e.g. schedule)
         # and add the derived/injected values on top.
         # Hashie::Mash, so indifferent access; do not .to_h (string keys would
         # break the :nickname ||= below).
-        chkbuild = host.properties.dig(:attributes, :chkbuild) || {}
+        chkbuild = host.properties.dig(:attributes, :chkbuild)
+        # The macOS hosts are named by ssh alias (fuji, ringo) instead of a
+        # rubyci.org DNS name; they opt in via explicit chkbuild attributes.
+        return unless host.name.end_with?('.rubyci.org') || chkbuild
+        chkbuild ||= {}
         # e.g. openbsd reports to rubyci as openbsd-current; keep an explicit
         # nickname from hosts.yml over the host-name-derived one.
         chkbuild[:nickname] ||= host.name.split('.').first

--- a/hosts.yml
+++ b/hosts.yml
@@ -269,3 +269,54 @@ fedora44-arm.rubyci.org:
     compress: false
     run_list:
       - recipes/default.rb
+
+# The macOS hosts are reached via ssh aliases from ~/.ssh/config (they sit
+# behind a ProxyCommand jump), not rubyci.org DNS names. sudo needs a
+# password on them, so apply with SUDO_PASSWORD set in the environment.
+# Everything runs as the hsbt login user; there is no chkbuild user.
+fuji: # macOS 15, Apple Silicon
+  properties:
+    attributes:
+      chkbuild:
+        nickname: osx1500arm
+        user: hsbt
+        # chkbuild checkout relative to the user's home directory; the
+        # macOS hosts historically use ~/Documents/cb, not ~/chkbuild.
+        dir: Documents/cb
+        schedule: "50 * * * *"
+        # Not an EC2 instance, so no instance profile; S3 upload
+        # credentials live in ~/.aws/credentials instead.
+        aws_credentials_file: true
+        env:
+          # The historical crontab always ran chkbuild with a Japanese UTF-8
+          # locale (encoding-sensitive tests) and C messages for parsable
+          # tool output.
+          LANG: ja_JP.utf-8
+          LC_MESSAGES: C
+        extra_builds:
+            # Second checkout built with YJIT disabled; both runs have their
+            # own lock, so sharing the schedule is safe.
+          - dir: Documents/cb-yjit
+            nickname: osx1500arm-no-yjit
+            schedule: "50 * * * *"
+    compress: false
+    run_list:
+      - recipes/macos.rb
+
+ringo: # macOS 14, Apple Silicon
+  properties:
+    attributes:
+      chkbuild:
+        nickname: osx1400arm
+        user: hsbt
+        dir: Documents/cb
+        schedule: "45 * * * *"
+        # Not an EC2 instance, so no instance profile; S3 upload
+        # credentials live in ~/.aws/credentials instead.
+        aws_credentials_file: true
+        env:
+          LANG: ja_JP.utf-8
+          LC_MESSAGES: C
+    compress: false
+    run_list:
+      - recipes/macos.rb

--- a/hosts.yml
+++ b/hosts.yml
@@ -271,8 +271,8 @@ fedora44-arm.rubyci.org:
       - recipes/default.rb
 
 # The macOS hosts are reached via ssh aliases from ~/.ssh/config (they sit
-# behind a ProxyCommand jump), not rubyci.org DNS names. sudo needs a
-# password on them, so apply with SUDO_PASSWORD set in the environment.
+# behind a ProxyCommand jump), not rubyci.org DNS names. NOPASSWD sudo comes
+# from a drop-in in /private/etc/sudoers.d on each host.
 # Everything runs as the hsbt login user; there is no chkbuild user.
 fuji: # macOS 15, Apple Silicon
   properties:
@@ -299,6 +299,7 @@ fuji: # macOS 15, Apple Silicon
           - dir: Documents/cb-yjit
             nickname: osx1500arm-no-yjit
             schedule: "50 * * * *"
+    nopasswd_sudo: true
     compress: false
     run_list:
       - recipes/macos.rb
@@ -317,6 +318,7 @@ ringo: # macOS 14, Apple Silicon
         env:
           LANG: ja_JP.utf-8
           LC_MESSAGES: C
+    nopasswd_sudo: true
     compress: false
     run_list:
       - recipes/macos.rb

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -6,19 +6,27 @@
 chkbuild = node[:chkbuild] || {}
 
 if chkbuild[:nickname]
+  # The Linux hosts run chkbuild as the dedicated chkbuild user; the macOS
+  # hosts run everything as the hsbt login user (attributes.chkbuild.user).
+  user = chkbuild[:user] || 'chkbuild'
+  home = node[:platform] == 'darwin' ? "/Users/#{user}" : "/home/#{user}"
+  # chkbuild checkout relative to the home directory (attributes.chkbuild.dir);
+  # the macOS hosts historically use ~/Documents/cb, not ~/chkbuild.
+  dir = chkbuild[:dir] || 'chkbuild'
+
   # Non-EC2 hosts (aws_credentials_file in hosts.yml) cannot use an
   # instance profile, so they keep a long-lived key in ~/.aws/credentials.
   # The key pair reaches node[:chkbuild] only when CHKBUILD_AWS_* are set
   # at apply time; a credential-less apply skips this and leaves the
   # existing file untouched.
   if chkbuild[:aws_access_key_id] && chkbuild[:aws_secret_access_key]
-    directory "/home/chkbuild/.aws" do
-      owner 'chkbuild'
+    directory "#{home}/.aws" do
+      owner user
       mode '700'
     end
 
-    file "/home/chkbuild/.aws/credentials" do
-      owner 'chkbuild'
+    file "#{home}/.aws/credentials" do
+      owner user
       mode '600'
       content [
         '[default]',
@@ -29,7 +37,7 @@ if chkbuild[:nickname]
     end
   end
 
-  crontab_path = "/home/chkbuild/.crontab"
+  crontab_path = "#{home}/.crontab"
 
   # Interval per host is chosen so that one full chkbuild cycle (all branches)
   # plus ~15min headroom fits within it; chkbuild aborts when the previous run
@@ -56,7 +64,7 @@ if chkbuild[:nickname]
   (chkbuild[:env] || {}).each do |key, value|
     lines << "#{key}=#{value}"
   end
-  lines << "#{schedule} cd ~/chkbuild && git pull origin master && #{command_prefix}~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
+  lines << "#{schedule} cd ~/#{dir} && git pull origin master && #{command_prefix}~/.rbenv/shims/ruby #{command} && rm -rf tmp/build"
   # Additional chkbuild checkouts on the same host
   # (attributes.chkbuild.extra_builds in hosts.yml), e.g. ~/chkbuild-no-yjit
   # reporting as ubuntu-no-yjit. RUBYCI_NICKNAME is overridden per line
@@ -69,13 +77,13 @@ if chkbuild[:nickname]
   # NOTE: no <<~ heredoc here; the mruby in mitamae <= 1.11 misparses it as
   # `content << ~CRON` and dies with NameError.
   file crontab_path do
-    owner 'chkbuild'
+    owner user
     mode '600'
     content lines.join("\n")
   end
 
-  execute "crontab -u chkbuild #{crontab_path}" do
-    not_if "crontab -l -u chkbuild 2>/dev/null | cmp -s - #{crontab_path}"
+  execute "crontab -u #{user} #{crontab_path}" do
+    not_if "crontab -l -u #{user} 2>/dev/null | cmp -s - #{crontab_path}"
   end
 else
   MItamae.logger.info "skipping chkbuild crontab (not a rubyci host)"

--- a/recipes/macos.rb
+++ b/recipes/macos.rb
@@ -1,5 +1,85 @@
 # macOS hosts (fuji, ringo): everything is set up for the hsbt login user;
 # OS provisioning, Xcode CLT and the MacPorts installer are out of scope.
-# MacPorts packages, rbenv and the chkbuild checkouts follow in later
-# changes.
+
+# Build dependencies for the chkbuild ruby builds, from MacPorts.
+# start-rubyci puts /opt/local/bin on PATH and configures with
+# --with-openssl-dir=/opt/local --with-libyaml-dir=/opt/local;
+# curl-ca-bundle provides /opt/local/etc/openssl/cert.pem for the
+# https-facing tests and rust is for YJIT. setrequested protects ports
+# that originally arrived as dependencies (and would otherwise be
+# reclaimed by `port reclaim`) once they are declared here.
+port = '/opt/local/bin/port'
+%w[
+  autoconf
+  automake
+  bison
+  curl-ca-bundle
+  gdbm
+  libtool
+  libyaml
+  openssl
+  rust
+].each do |pkg|
+  execute "#{port} -N install #{pkg}" do
+    not_if "#{port} -q installed #{pkg} | grep -q '(active)'"
+  end
+
+  execute "#{port} setrequested #{pkg}" do
+    not_if "#{port} echo requested | grep -q '^#{pkg} '"
+  end
+end
+
+node.reverse_merge!(
+  rbenv: {
+    user: 'hsbt',
+    group: 'staff',
+    global: '3.4.8',
+    versions: %w[
+      3.4.8
+    ],
+    # Build dependencies come from MacPorts above; the plugin's dependency
+    # recipe only knows Linux package managers.
+    install_dependency: false,
+  },
+  'ruby-build': {
+    build_envs: {
+      'RUBY_CONFIGURE_OPTS': '--disable-install-doc --disable-dtrace',
+    },
+  },
+  'rbenv-default-gems': {
+    'default-gems': [
+      'aws-sdk-s3',
+    ],
+  },
+)
+
+# Same workaround as default.rb: mitamae's git resource cannot update a
+# repo whose HEAD was moved off the deploy branch.
+%w[
+  /Users/hsbt/.rbenv
+  /Users/hsbt/.rbenv/plugins/ruby-build
+  /Users/hsbt/.rbenv/plugins/rbenv-default-gems
+].each do |repo|
+  execute "remove stale deploy branch in #{repo}" do
+    command "git -C #{repo} branch -D deploy"
+    user 'hsbt'
+    only_if "test \"$(git -C #{repo} rev-parse --abbrev-ref HEAD)\" != deploy && git -C #{repo} rev-parse -q --verify refs/heads/deploy"
+  end
+end
+
+include_recipe 'rbenv::user'
+
+# chkbuild checkouts under ~/Documents (the primary build plus any
+# extra_builds from hosts.yml); each keeps itself up to date with the
+# git pull in its cron line, so existing checkouts are left alone.
+chkbuild = node[:chkbuild] || {}
+dirs = [chkbuild[:dir], *(chkbuild[:extra_builds] || []).map { |extra| extra[:dir] }].compact
+dirs.each do |dir|
+  git "/Users/hsbt/#{dir}" do
+    repository 'https://github.com/ruby/chkbuild'
+    user 'hsbt'
+    not_if "test -e /Users/hsbt/#{dir}"
+  end
+end
+
 include_recipe 'chkbuild-cron'

--- a/recipes/macos.rb
+++ b/recipes/macos.rb
@@ -1,5 +1,13 @@
-# macOS hosts (fuji, ringo): everything is set up for the hsbt login user;
-# OS provisioning, Xcode CLT and the MacPorts installer are out of scope.
+# macOS hosts (fuji, ringo): OS provisioning, Xcode CLT and the MacPorts
+# installer are out of scope.
+#
+# The user owning everything (rbenv, checkouts, crontab) comes from
+# attributes.chkbuild.user in hosts.yml (currently hsbt), so switching to a
+# dedicated chkbuild user later only needs that attribute changed; the user
+# itself must already exist.
+chkbuild = node[:chkbuild] || {}
+user = chkbuild[:user] || 'chkbuild'
+home = "/Users/#{user}"
 
 # Build dependencies for the chkbuild ruby builds, from MacPorts.
 # start-rubyci puts /opt/local/bin on PATH and configures with
@@ -31,7 +39,7 @@ end
 
 node.reverse_merge!(
   rbenv: {
-    user: 'hsbt',
+    user: user,
     group: 'staff',
     global: '3.4.8',
     versions: %w[
@@ -55,14 +63,14 @@ node.reverse_merge!(
 
 # Same workaround as default.rb: mitamae's git resource cannot update a
 # repo whose HEAD was moved off the deploy branch.
-%w[
-  /Users/hsbt/.rbenv
-  /Users/hsbt/.rbenv/plugins/ruby-build
-  /Users/hsbt/.rbenv/plugins/rbenv-default-gems
+%W[
+  #{home}/.rbenv
+  #{home}/.rbenv/plugins/ruby-build
+  #{home}/.rbenv/plugins/rbenv-default-gems
 ].each do |repo|
   execute "remove stale deploy branch in #{repo}" do
     command "git -C #{repo} branch -D deploy"
-    user 'hsbt'
+    user user
     only_if "test \"$(git -C #{repo} rev-parse --abbrev-ref HEAD)\" != deploy && git -C #{repo} rev-parse -q --verify refs/heads/deploy"
   end
 end
@@ -72,13 +80,12 @@ include_recipe 'rbenv::user'
 # chkbuild checkouts under ~/Documents (the primary build plus any
 # extra_builds from hosts.yml); each keeps itself up to date with the
 # git pull in its cron line, so existing checkouts are left alone.
-chkbuild = node[:chkbuild] || {}
 dirs = [chkbuild[:dir], *(chkbuild[:extra_builds] || []).map { |extra| extra[:dir] }].compact
 dirs.each do |dir|
-  git "/Users/hsbt/#{dir}" do
+  git "#{home}/#{dir}" do
     repository 'https://github.com/ruby/chkbuild'
-    user 'hsbt'
-    not_if "test -e /Users/hsbt/#{dir}"
+    user user
+    not_if "test -e #{home}/#{dir}"
   end
 end
 

--- a/recipes/macos.rb
+++ b/recipes/macos.rb
@@ -1,0 +1,5 @@
+# macOS hosts (fuji, ringo): everything is set up for the hsbt login user;
+# OS provisioning, Xcode CLT and the MacPorts installer are out of scope.
+# MacPorts packages, rbenv, the chkbuild checkouts and the crontab follow in
+# later changes; this stub keeps the run_list in hosts.yml applicable.
+MItamae.logger.info "macos.rb: recipe body not implemented yet"

--- a/recipes/macos.rb
+++ b/recipes/macos.rb
@@ -1,5 +1,5 @@
 # macOS hosts (fuji, ringo): everything is set up for the hsbt login user;
 # OS provisioning, Xcode CLT and the MacPorts installer are out of scope.
-# MacPorts packages, rbenv, the chkbuild checkouts and the crontab follow in
-# later changes; this stub keeps the run_list in hosts.yml applicable.
-MItamae.logger.info "macos.rb: recipe body not implemented yet"
+# MacPorts packages, rbenv and the chkbuild checkouts follow in later
+# changes.
+include_recipe 'chkbuild-cron'


### PR DESCRIPTION
The macOS hosts fuji and ringo were configured by hand and their crontabs had drifted apart. This brings them under the same hocho/mitamae management as the Linux hosts. They are addressed by ssh aliases from `~/.ssh/config` and everything runs as the user named by `attributes.chkbuild.user`, currently the hsbt login user, so a dedicated chkbuild user can take over later by changing one attribute. `recipes/macos.rb` declares the MacPorts build dependencies, manages rbenv with `aws-sdk-s3` as a default gem, creates the chkbuild checkouts under `~/Documents` and installs the crontab. `chkbuild-cron.rb` is parameterized by user, home and checkout directory and keeps its previous output on the Linux hosts. Both hosts are applied and a re-run reports no changes. OS provisioning, Xcode Command Line Tools and the MacPorts installer stay out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
