### PR TITLE
Move the macOS chkbuild checkouts out of ~/Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ When `attributes.chkbuild.command` is `start-cross-rubyci`, `recipes/crossruby.r
 
 ### macOS hosts (fuji, ringo)
 
-The macOS hosts are addressed by the ssh aliases `fuji` and `ringo` from `~/.ssh/config`, not by rubyci.org names. Everything runs as the pre-existing user named by `attributes.chkbuild.user` in `hosts.yml`, currently the hsbt login user. `recipes/macos.rb` manages the MacPorts build dependencies, rbenv with aws-sdk-s3 as a default gem, the chkbuild checkouts under `~/Documents` and the crontab. OS provisioning, Xcode Command Line Tools and the MacPorts installer itself are out of scope. sudo must be passwordless, via a drop-in in `/private/etc/sudoers.d` (the file name must not contain a period). With that in place `bin/hocho apply fuji` works like any other host.
+The macOS hosts are addressed by the ssh aliases `fuji` and `ringo` from `~/.ssh/config`, not by rubyci.org names. Everything runs as the pre-existing user named by `attributes.chkbuild.user` in `hosts.yml`, currently the hsbt login user. `recipes/macos.rb` manages the MacPorts build dependencies, rbenv with aws-sdk-s3 as a default gem, the chkbuild checkouts and the crontab. OS provisioning, Xcode Command Line Tools and the MacPorts installer itself are out of scope. sudo must be passwordless, via a drop-in in `/private/etc/sudoers.d` (the file name must not contain a period). With that in place `bin/hocho apply fuji` works like any other host.
+
+Keep the checkouts out of `~/Desktop`, `~/Documents` and `~/Downloads`. macOS TCC denies a cron-launched rbenv ruby access to those directories, and because the crontab sets `MAILTO=""` the build dies without a trace: no build directory, no line in `tmp/build/.lock`, no mail. `sudo log show --start "<cron minute>" --info` on the host shows the `sandboxd rejected approval request from ruby for kTCCServiceSystemPolicyDocumentsFolder` denial. Running the same command by hand over ssh succeeds, because sshd holds Full Disk Access and the child inherits it.
 
 ### All chkbuild
 

--- a/bin/hocho
+++ b/bin/hocho
@@ -2,4 +2,14 @@
 if [[ ! -d plugins/itamae-plugin-recipe-rbenv/.git ]]; then
   git submodule init && git submodule update
 fi
+
+# A bare `bundle` resolves to /usr/bin/bundle, and so to the macOS system
+# Ruby 2.6, in any environment that lists /usr/bin ahead of the version
+# manager; bundler 4 dies there with an unhelpful NameError about
+# Gem::Resolver::APISet::GemParser. `mise exec` does not help because it
+# keeps the ambient order, so put the mise ruby in front explicitly.
+# Environments without mise keep whatever ruby they already resolve to.
+if ruby_prefix=$(mise where ruby 2>/dev/null) && [[ -x "${ruby_prefix}/bin/bundle" ]]; then
+  PATH="${ruby_prefix}/bin:${PATH}"
+fi
 exec bundle exec hocho "$@"

--- a/hosts.yml
+++ b/hosts.yml
@@ -280,9 +280,12 @@ fuji: # macOS 15, Apple Silicon
       chkbuild:
         nickname: osx1500arm
         user: hsbt
-        # chkbuild checkout relative to the user's home directory; the
-        # macOS hosts historically use ~/Documents/cb, not ~/chkbuild.
-        dir: Documents/cb
+        # chkbuild checkout relative to the user's home directory. These
+        # used to live under ~/Documents, but macOS TCC denies a
+        # cron-launched rbenv ruby access to that directory, which killed
+        # every build silently; keep the checkouts outside the protected
+        # Desktop/Documents/Downloads trio.
+        dir: chkbuild
         schedule: "50 * * * *"
         # Not an EC2 instance, so no instance profile; S3 upload
         # credentials live in ~/.aws/credentials instead.
@@ -296,7 +299,7 @@ fuji: # macOS 15, Apple Silicon
         extra_builds:
             # Second checkout built with YJIT disabled; both runs have their
             # own lock, so sharing the schedule is safe.
-          - dir: Documents/cb-yjit
+          - dir: chkbuild-no-yjit
             nickname: osx1500arm-no-yjit
             schedule: "50 * * * *"
     nopasswd_sudo: true
@@ -310,7 +313,7 @@ ringo: # macOS 14, Apple Silicon
       chkbuild:
         nickname: osx1400arm
         user: hsbt
-        dir: Documents/cb
+        dir: chkbuild
         schedule: "45 * * * *"
         # Not an EC2 instance, so no instance profile; S3 upload
         # credentials live in ~/.aws/credentials instead.

--- a/recipes/chkbuild-cron.rb
+++ b/recipes/chkbuild-cron.rb
@@ -10,8 +10,7 @@ if chkbuild[:nickname]
   # hosts run everything as the hsbt login user (attributes.chkbuild.user).
   user = chkbuild[:user] || 'chkbuild'
   home = node[:platform] == 'darwin' ? "/Users/#{user}" : "/home/#{user}"
-  # chkbuild checkout relative to the home directory (attributes.chkbuild.dir);
-  # the macOS hosts historically use ~/Documents/cb, not ~/chkbuild.
+  # chkbuild checkout relative to the home directory (attributes.chkbuild.dir).
   dir = chkbuild[:dir] || 'chkbuild'
 
   # Non-EC2 hosts (aws_credentials_file in hosts.yml) cannot use an

--- a/recipes/macos.rb
+++ b/recipes/macos.rb
@@ -77,9 +77,9 @@ end
 
 include_recipe 'rbenv::user'
 
-# chkbuild checkouts under ~/Documents (the primary build plus any
-# extra_builds from hosts.yml); each keeps itself up to date with the
-# git pull in its cron line, so existing checkouts are left alone.
+# chkbuild checkouts (the primary build plus any extra_builds from
+# hosts.yml); each keeps itself up to date with the git pull in its cron
+# line, so existing checkouts are left alone.
 dirs = [chkbuild[:dir], *(chkbuild[:extra_builds] || []).map { |extra| extra[:dir] }].compact
 dirs.each do |dir|
   git "#{home}/#{dir}" do


### PR DESCRIPTION
The macOS builds stopped updating on rubyci.org after the 2026-07-29 OS update. cron kept firing and `git pull` kept succeeding, but `start-rubyci` died immediately, because macOS TCC denies a cron-launched rbenv ruby access to `~/Documents`. With `MAILTO=""` in the crontab that left nothing behind, no build directory, no line in `tmp/build/.lock`, no mail. Running the same command by hand over ssh works, since sshd holds Full Disk Access and the child inherits it, which is what made this hard to spot.

Moving the checkouts to `~/chkbuild` takes them out of the protected Desktop/Documents/Downloads trio, so the schedule no longer depends on a TCC grant that has to be renewed on every Ruby upgrade. Both hosts are moved and applied, and their next cron runs started normally.

The second commit is unrelated. `bin/hocho` resolved `bundle` to `/usr/bin/bundle` whenever `/usr/bin` came first in `PATH`, where bundler 4 cannot load under the system Ruby 2.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
