### PR TITLE
Consolidate the CDN log sinks on Datadog and archive to S3

### DIFF
--- a/cdn/README.md
+++ b/cdn/README.md
@@ -2,6 +2,8 @@
 
 Terraform configuration for the Fastly services of ruby-lang.org. Each service lives in its own `.tf` file. Custom VCL is under `vcl/`, and the shared Datadog log format is `logging/datadog_format.json`.
 
+Datadog is the only log sink. Long term storage of the same events runs through Datadog's S3 log archive, managed in `datadog/`, because the index retention this org's contract allows is 15 days.
+
 The `ftp` service has been dormant since 2018 and is kept with `activate = false`. `ftp.ruby-lang.org` is actually served by the `cache` service.
 
 The `logs.rubyci.org` service fronts the public `rubyci` S3 bucket (chkbuild logs). Switching rubyci.org log links over to it happens in the ruby/rubyci repository.
@@ -12,7 +14,7 @@ Two things about the Fastly API token. It needs the TLS management permission, w
 
 ## Usage
 
-Credentials come from `~/.config/fastly/token.sh`, which must export `FASTLY_API_KEY` (global scope token), `TF_VAR_datadog_token`, `TF_VAR_logging_s3_access_key`, and `TF_VAR_logging_s3_secret_key`. The state backend also needs AWS credentials that can read and write `s3://ruby-lang-terraform-state`, supplied through any standard AWS mechanism such as `AWS_PROFILE` or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`.
+Credentials come from `~/.config/fastly/token.sh`, which must export `FASTLY_API_KEY` (global scope token) and `TF_VAR_datadog_token`. The state backend also needs AWS credentials that can read and write `s3://ruby-lang-terraform-state`, supplied through any standard AWS mechanism such as `AWS_PROFILE` or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`.
 
 ```
 source ~/.config/fastly/token.sh

--- a/cdn/cache.tf
+++ b/cdn/cache.tf
@@ -117,23 +117,11 @@ resource "fastly_service_vcl" "cache" {
     token             = var.datadog_token
   }
 
-  logging_s3 {
-    bucket_name       = "ftp.r-l.o.log"
-    domain            = "s3.amazonaws.com"
-    file_max_bytes    = 0
-    format            = "%h %l %u %t \"%r\" %>s %b"
-    format_version    = 2
-    gzip_level        = 0
-    message_type      = "classic"
-    name              = "ftp.r-l.o.log"
-    path              = "/"
-    period            = 3600
-    processing_region = "none"
-    redundancy        = "standard"
-    s3_access_key     = var.logging_s3_access_key
-    s3_secret_key     = var.logging_s3_secret_key
-    timestamp_format  = "%Y-%m-%dT%H:%M:%S.000"
-  }
+  # The direct S3 sink is gone. It was this service only, in common log format,
+  # so it carried no user agent, no referer and no cache state. Long term storage
+  # now runs through Datadog's log archive for all six services, which is managed
+  # in datadog/ and queried with Athena. Objects already in ftp.r-l.o.log are
+  # untouched, only new writes stopped.
 
   vcl {
     content = file("${path.module}/vcl/cache.vcl")

--- a/cdn/cache_dev.tf
+++ b/cdn/cache_dev.tf
@@ -102,8 +102,6 @@ resource "fastly_service_vcl" "cache_dev" {
     name = "cache-rlo-dev.global.ssl.fastly.net"
   }
 
-  # No logging_s3 counterpart: the production bucket ftp.r-l.o.log is an
-  # access-log archive for cache, and dev traffic does not belong in it.
   logging_datadog {
     format            = file("${path.module}/logging/datadog_format.json")
     format_version    = 2

--- a/cdn/variables.tf
+++ b/cdn/variables.tf
@@ -3,15 +3,3 @@ variable "datadog_token" {
   type        = string
   sensitive   = true
 }
-
-variable "logging_s3_access_key" {
-  description = "AWS access key for the ftp.r-l.o.log S3 logging bucket"
-  type        = string
-  sensitive   = true
-}
-
-variable "logging_s3_secret_key" {
-  description = "AWS secret key for the ftp.r-l.o.log S3 logging bucket"
-  type        = string
-  sensitive   = true
-}

--- a/datadog/.gitignore
+++ b/datadog/.gitignore
@@ -1,0 +1,4 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars

--- a/datadog/.terraform.lock.hcl
+++ b/datadog/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version     = "4.17.0"
+  constraints = "~> 4.17"
+  hashes = [
+    "h1:R1tZk6JUGe2SfmMOQmbxMaXQo/z/Q2iocfsmaSOHebg=",
+    "zh:178b8b4c0d28632ecd51ea02e180a8547370458fc9e4fa3ef65fcbf814309d4f",
+    "zh:1ec81b44d7ab6b8644fdde6a6222e60d8207d23ff617cf8809de6dad4438a657",
+    "zh:3195cf3a2c2dad4a47f20058caadfe5bbca1517170e56fc4a935b860708b7d82",
+    "zh:59afdfd3099828ddb3ac35a8e97aebe69b2e0b364ff075bb85771bbe441057f5",
+    "zh:76768748f3e77ebd9271baf7d6e11495e225e94e0b6464b0eca05d0fdfa21b1a",
+    "zh:812bb8101db6b66869bfa900bd866cdcba83f682f4135c84415cf492ffacaa5b",
+    "zh:90ba4eedc1fe598e7f39b69b529787e44d598253836f12454217d6c2904669bf",
+    "zh:9a511ff60d392ec32a78a97823ce627dc02987a3cfd784d41ef063f07b9a5179",
+    "zh:9e0859de141e9a388befde91483f683f13908eb2fde91fd0c8af8100ff6aeaaf",
+    "zh:a6f68369e00f39e5e7662b7882f33e9d0ff5b7543f952878a1b58bb7cb3689bb",
+    "zh:d22937c8554003759f2127a0e71be3a05da614c21474d13a51454a44639e5094",
+    "zh:d9997ebc051d782d705a8aee84caaaa96f89c4e5437c5ff19c6ab24a675d1da4",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+    "zh:ff9655a98db65d0934f5c80008649c872420e236703e1c92edaafc6dc52eae7f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.57.1"
+  constraints = "~> 6.57"
+  hashes = [
+    "h1:Mz2BVjntgeXCYLdhPCpgTBvGNPmxJBJxqq5M4r27Hc8=",
+    "zh:2d29e22480a81c21fb3f2fd52f9bd3ca4a82c37f3bb1b1036e881e42cddc75a1",
+    "zh:33aeb08e9973199b30f8a8e48a58dc67cfb6e32879f7a1c05c521899fe718f53",
+    "zh:37b7f977a7e7d45ad11d42958bc264873fb34573eee925915038ea05607abc9e",
+    "zh:41ebdcf4bcd073a01d58505a5f5118b85668de357d2d9f266926923e817a1842",
+    "zh:43093dfc3559c2c0467c92f48b29ae0221d52e912fce03dd77abd90806fdcc7d",
+    "zh:63b4252933e828d3590c0c64b827ec0f8955aa52df719fe67f45a846111fccc4",
+    "zh:7473b036e9f8167c7a09e4865de95d07922eae6a612b94e819d44c87ba5298de",
+    "zh:783c73e66bf50a74983803e1ec6d6237bae2891f9d4fd4824cfd5350121552ae",
+    "zh:83681e1d8d002048b76d7144cb96c8c8501dc973d1fee41b7579a46ad9eb04c2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b08b4168d4e2a81badbbe65d95f692ed3292c2b71cd00b9889a3bb7cf54c1188",
+    "zh:b4320ca25f4f67beebcbd6563ece2e490bd9dcb0a7e59b5d7a437ddaf53768ed",
+    "zh:d7f99254d6e05bac3dffae9b437c47cd807b4e66d941e56364be0a28ead418bd",
+    "zh:e433e91689758a341c91840cc7b5d3a3c5089004766d20659d57199b88ad8a5f",
+    "zh:e4c5a9b0f96a5fe2b5ed5592d4c2ac33240cf5308bcb14e52d6f2e0eb183a014",
+    "zh:fc4b554ae98e40e3ab6878ec9501ba2b05213d30668ee357d48b207993ffbe03",
+  ]
+}

--- a/datadog/README.md
+++ b/datadog/README.md
@@ -1,0 +1,47 @@
+# datadog
+
+Terraform configuration for the Datadog org (AP1) that receives the Fastly CDN logs from `cdn/`. `index.tf` holds the retention of the `main` index, `archive.tf` the S3 log archive and the AWS integration role it assumes.
+
+Retention is two tiered. The `main` index keeps events queryable for a year, Standard Tier for the first 30 days and Flex Tier after that, and the archive holds the same events in S3 from ingest onwards. Datadog has no setting that moves logs to S3 after N months, so the archive is written continuously and the index expiry is what decides when S3 holds the only copy. Reading past that age means rehydrating the archive back into an index.
+
+The bucket lifecycle cools objects to `GLACIER_IR` at the same age. That is the coldest storage class Datadog can read directly, so do not push it further to Deep Archive.
+
+The archive is scoped to `source:fastly`. Heroku application logs stay out of it, since they carry more than CDN access data and nothing asked for a year of them.
+
+## Querying the archive
+
+Anything older than the index retention lives only in S3. `athena.tf` registers it as `ruby_lang_logs.fastly` in the `ruby-lang-logs` workgroup. Partition projection covers `dt` and `hour`, so no crawler runs and no partition ever needs adding.
+
+`service` is a column, not a partition. Datadog's path is only `dt=<date>/hour=<hour>`, and `partitioning_attributes` writes a sidecar index for Datadog's own archive search instead of an S3 prefix, so prune with `dt` and filter services in SQL. The opaque IDs map to host names in `cdn/*.tf`.
+
+```sql
+SELECT service, count(*) AS hits, sum(attributes.network.bytes_written) AS bytes
+FROM ruby_lang_logs.fastly
+WHERE dt BETWEEN '20260801' AND '20260831'
+GROUP BY service
+```
+
+The declared columns are the ones worth querying. Datadog ships around 50 attributes and the SerDe ignores the undeclared ones, so add a column when a query needs it. Some of them come from Datadog rather than Fastly, including `attributes.http.url_details.path` and the parsed user agent.
+
+Query results go to `athena-results/` in the same bucket and expire after 7 days. The lifecycle rule that cools the archive is scoped to `fastly/` so it leaves them alone.
+
+## Usage
+
+Credentials come from `~/.config/datadog/token.sh`, which must export `DD_API_KEY` and `DD_APP_KEY`. The Application Key needs the scopes for modifying log indexes, writing log archives, and editing the AWS integration. `DD_API_KEY` is an org API key and is unrelated to `TF_VAR_datadog_token` in `cdn/`, which is the intake key Fastly ships logs with.
+
+Do not set up the AWS integration in the Datadog UI. `datadog_integration_aws_account` creates the registration and generates its own external ID, and the UI flow would both duplicate the registration and, through its CloudFormation template, create an IAM role that collides with `aws_iam_role.datadog`.
+
+The state backend and the S3 resources need AWS credentials for the ruby-lang account. `AWS_PROFILE=ruby-lang` works here.
+
+The `main` index already exists, so import it before the first plan.
+
+```
+source ~/.config/datadog/token.sh
+terraform init
+terraform import datadog_logs_index.main main
+terraform plan
+```
+
+Removing `logging_s3` from `cdn/cache.tf` waits until this archive has objects in the bucket. The other order leaves a gap where neither sink keeps the access logs.
+
+State is stored in `s3://ruby-lang-terraform-state/datadog/terraform.tfstate` (ap-northeast-1, versioned, S3 native locking).

--- a/datadog/archive.tf
+++ b/datadog/archive.tf
@@ -1,0 +1,210 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Referenced by both the role and the integration. Pointing the integration at
+  # aws_iam_role.datadog.name instead would be a cycle, because the role's trust
+  # policy needs the external ID that the integration generates.
+  datadog_role_name = "DatadogIntegrationRole"
+}
+
+# Datadog writes this archive continuously, from ingest. There is no "move to S3
+# after N months" knob, so the bucket holds every event from day one and the
+# index retention decides when it stops being the second copy and becomes the
+# only one.
+resource "aws_s3_bucket" "log_archive" {
+  bucket = var.archive_bucket
+}
+
+resource "aws_s3_bucket_public_access_block" "log_archive" {
+  bucket = aws_s3_bucket.log_archive.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "log_archive" {
+  bucket = aws_s3_bucket.log_archive.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "log_archive" {
+  bucket = aws_s3_bucket.log_archive.id
+
+  rule {
+    id     = "cold-once-the-index-expires"
+    status = "Enabled"
+
+    # Scoped to the archive, so Athena query results under athena-results/ are
+    # not dragged into Glacier by the same rule.
+    filter {
+      prefix = "fastly/"
+    }
+
+    # Glacier Instant Retrieval is the coldest class Datadog still reads
+    # directly. Flexible Retrieval and Deep Archive need an S3 restore first,
+    # which is why the old chkbuild logs in the rubyci bucket answer 403.
+    transition {
+      days          = var.archive_cold_after_days
+      storage_class = "GLACIER_IR"
+    }
+  }
+
+  rule {
+    id     = "drop-athena-results"
+    status = "Enabled"
+
+    filter {
+      prefix = "athena-results/"
+    }
+
+    expiration {
+      days = 7
+    }
+  }
+}
+
+data "aws_iam_policy_document" "datadog_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.datadog_aws_account_id]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [datadog_integration_aws_account.main.auth_config.aws_auth_config_role.external_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "datadog" {
+  name               = local.datadog_role_name
+  assume_role_policy = data.aws_iam_policy_document.datadog_assume_role.json
+}
+
+data "aws_iam_policy_document" "log_archive" {
+  statement {
+    effect = "Allow"
+
+    # PutObject writes the archive. GetObject and ListBucket are what archive
+    # search and rehydration read it back with.
+    actions   = ["s3:PutObject", "s3:GetObject"]
+    resources = ["${aws_s3_bucket.log_archive.arn}/*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.log_archive.arn]
+  }
+
+  # Nothing to do with the archive. The integration health check calls this even
+  # with metrics_config disabled, and without it the AWS integration screen sits
+  # on a permanent "missing critical IAM permissions" alert that reads like a
+  # real outage. It lists metric names only, never values, and does not turn
+  # metrics collection back on. The action takes no resource qualifier.
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudwatch:ListMetrics"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "log_archive" {
+  name   = "DatadogLogArchive"
+  role   = aws_iam_role.datadog.id
+  policy = data.aws_iam_policy_document.log_archive.json
+}
+
+# The archive authenticates by assuming the role above, and Datadog only allows
+# that for an account registered here. Metrics, traces and resource collection
+# stay off, because the role carries S3 permissions and nothing else. Collecting
+# CloudWatch metrics for the rubyci fleet is worth doing, but it needs a far
+# wider IAM policy and belongs in its own change.
+resource "datadog_integration_aws_account" "main" {
+  aws_account_id = data.aws_caller_identity.current.account_id
+  aws_partition  = "aws"
+
+  # Optional and computed. Leaving it out makes every plan show
+  # `[] -> (known after apply)`, which drags the external ID and the role's trust
+  # policy into a diff that never settles.
+  account_tags = []
+
+  aws_regions {
+    include_only = ["ap-northeast-1"]
+  }
+
+  auth_config {
+    aws_auth_config_role {
+      role_name = local.datadog_role_name
+    }
+  }
+
+  logs_config {
+    lambda_forwarder {}
+  }
+
+  metrics_config {
+    enabled = false
+
+    namespace_filters {}
+  }
+
+  resources_config {
+    extended_collection = false
+  }
+
+  traces_config {
+    xray_services {}
+  }
+}
+
+resource "datadog_logs_archive" "fastly" {
+  name  = "fastly-cdn-logs"
+  query = "source:fastly"
+
+  # Keeps the Datadog tags on the archived events, so a rehydration comes back
+  # with the same facets as the original.
+  include_tags = true
+
+  # Explicitly empty, not omitted: omitting it leaves whatever the API already
+  # holds, and Terraform reports a successful update while the archive keeps the
+  # old value.
+  partitioning_attributes = []
+
+  # Partitioning is off because it does not partition the S3 path, which stays
+  # dt=<date>/hour=<hour>; it writes a `*.idx.<base64 attr>.partitionMetadata.zst`
+  # sidecar next to each object for Datadog's own archive search. Athena reads
+  # every file under the prefix and only skips names starting with `_` or `.`,
+  # so those sidecars would reach the JSON SerDe as zstd binary. Athena is the
+  # primary path for anything older than the index retention, so it wins.
+
+  s3_archive {
+    account_id = data.aws_caller_identity.current.account_id
+    bucket     = aws_s3_bucket.log_archive.id
+    path       = "fastly"
+    role_name  = local.datadog_role_name
+
+    # The lifecycle rule cools these objects down later. Writing them cold from
+    # the start would only slow down the window the index still covers.
+    storage_class = "STANDARD"
+  }
+
+  # Datadog verifies write access when the archive is created, so the role needs
+  # its policy and its registration first.
+  depends_on = [
+    aws_iam_role_policy.log_archive,
+    datadog_integration_aws_account.main,
+  ]
+}

--- a/datadog/athena.tf
+++ b/datadog/athena.tf
@@ -1,0 +1,100 @@
+# Athena is how anything older than the index retention gets queried. The
+# archive is the only copy at that point, and rehydrating it back into Datadog
+# re-indexes, which this org's contract limits the same way it limits retention.
+resource "aws_glue_catalog_database" "logs" {
+  name = "ruby_lang_logs"
+}
+
+resource "aws_glue_catalog_table" "fastly" {
+  name          = "fastly"
+  database_name = aws_glue_catalog_database.logs.name
+  table_type    = "EXTERNAL_TABLE"
+
+  partition_keys {
+    name = "dt"
+    type = "string"
+  }
+
+  partition_keys {
+    name = "hour"
+    type = "string"
+  }
+
+  parameters = {
+    EXTERNAL = "TRUE"
+
+    # Partition projection instead of a crawler. Datadog's layout is already
+    # dt=<date>/hour=<hour>, so the partitions are computable and nothing has to
+    # scan the bucket to discover them. Projecting a day that was never written
+    # costs nothing, Athena just finds no objects.
+    "projection.enabled"          = "true"
+    "projection.dt.type"          = "date"
+    "projection.dt.format"        = "yyyyMMdd"
+    "projection.dt.range"         = "20260730,NOW"
+    "projection.dt.interval"      = "1"
+    "projection.dt.interval.unit" = "DAYS"
+    "projection.hour.type"        = "integer"
+    "projection.hour.range"       = "0,23"
+    "projection.hour.digits"      = "2"
+    "storage.location.template"   = "s3://${aws_s3_bucket.log_archive.id}/fastly/dt=$${dt}/hour=$${hour}"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.log_archive.id}/fastly/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+
+      parameters = {
+        # `date` is a Hive type name and would need backticks in every query.
+        "mapping.log_date" = "date"
+
+        # A stray non-JSON object under the prefix yields null rows instead of
+        # failing the whole query. Datadog wrote such a file once, when
+        # partitioning_attributes was still set.
+        "ignore.malformed.json" = "true"
+      }
+    }
+
+    # Only the fields worth querying. The SerDe ignores the rest, so the other 40
+    # odd attributes Datadog ships need no declaration until something needs one.
+    columns {
+      name = "log_date"
+      type = "string"
+    }
+
+    columns {
+      name = "service"
+      type = "string"
+    }
+
+    columns {
+      name = "host"
+      type = "string"
+    }
+
+    columns {
+      name = "status"
+      type = "string"
+    }
+
+    columns {
+      name = "attributes"
+      type = "struct<http:struct<method:string,url:string,status_code:string,useragent:string,referer:string,request_time_ms:bigint,url_details:struct<path:string>>,network:struct<bytes_written:bigint,bytes_read:bigint,client:struct<ip:string,name:string,number:string>,geoip:struct<geo_country_code:string,geo_city:string>>,is_cacheable:boolean,server_datacenter:string,origin_host:string>"
+    }
+  }
+}
+
+resource "aws_athena_workgroup" "logs" {
+  name = "ruby-lang-logs"
+
+  configuration {
+    enforce_workgroup_configuration = true
+
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.log_archive.id}/athena-results/"
+    }
+  }
+}

--- a/datadog/index.tf
+++ b/datadog/index.tf
@@ -1,0 +1,23 @@
+# Imported, never created. Datadog ships `main` with the org, and applying this
+# without `terraform import datadog_logs_index.main main` first would try to add
+# a second index of the same name.
+resource "datadog_logs_index" "main" {
+  name = "main"
+
+  # Everything that reaches the org. Narrowing this drops events that no other
+  # index claims, silently.
+  filter {
+    query = ""
+  }
+
+  # No flex_retention_days. The Flex Tier is not in this org's contract, and
+  # setting it answers 403 "Out of contract retentions are not authorized". The
+  # S3 archive in archive.tf is what holds events past retention_days, and
+  # reading them back means rehydrating.
+  retention_days = var.index_retention_days
+
+  # Fastly sends around 1.9M events a day, three quarters of it
+  # docs.ruby-lang.org. A daily cap would drop the tail of a busy day instead of
+  # billing for it, and the org is on a plan where volume is not the constraint.
+  disable_daily_limit = true
+}

--- a/datadog/variables.tf
+++ b/datadog/variables.tf
@@ -1,0 +1,35 @@
+variable "archive_bucket" {
+  description = "S3 bucket that holds the Datadog log archive"
+  type        = string
+  default     = "ruby-lang-log-archive"
+}
+
+variable "datadog_aws_account_id" {
+  description = "Datadog's own AWS account ID, the trusted principal of the integration role"
+  type        = string
+
+  # Site specific, and the UI never shows it: it only hands out the external ID
+  # and links to the docs, which fill this in client side. US1, US3, US5 and EU
+  # share 464622532012, which is also the default baked into Datadog's
+  # CloudFormation templates, but AP1 does not. The full per-site table lives in
+  # aws_customer_access_id in DataDog/documentation, assets/scripts/config/
+  # regions.config.js. Getting it wrong fails as "Datadog is unable to
+  # authenticate with AWS role" with no AssumeRole event on this side, because a
+  # trust policy rejection is logged in the caller's account.
+  default = "417141415827"
+}
+
+variable "index_retention_days" {
+  description = "Days events stay in the main index. Past this age the S3 archive is the only copy"
+  type        = number
+
+  # 15 is what this org's contract allows. Both 30 and any Flex Tier value are
+  # rejected with 403 "Out of contract retentions are not authorized".
+  default = 15
+}
+
+variable "archive_cold_after_days" {
+  description = "Age at which archived objects move to GLACIER_IR"
+  type        = number
+  default     = 365
+}

--- a/datadog/versions.tf
+++ b/datadog/versions.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.10"
+
+  backend "s3" {
+    bucket       = "ruby-lang-terraform-state"
+    key          = "datadog/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+  }
+
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = "~> 4.17"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.57"
+    }
+  }
+}
+
+provider "datadog" {
+  # The org is on AP1. The provider defaults to the US1 endpoints, which answer
+  # 403 Forbidden for an AP1 key.
+  api_url = "https://api.ap1.datadoghq.com/"
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}


### PR DESCRIPTION
Only `cache` was writing access logs to S3, in common log format, while all six Fastly services already sent the full format to Datadog. That left `docs.ruby-lang.org`, three quarters of the volume, with no copy outside the index, and it kept two static IAM keys alive for one service.

Datadog is now the only sink and long term storage runs through its S3 log archive. This carries more weight than expected, because the contract on this org caps index retention at 15 days and both a longer Standard retention and any Flex Tier value answer 403. Anything older than 15 days lives only in `s3://ruby-lang-log-archive`, so `datadog/athena.tf` registers the archive as `ruby_lang_logs.fastly` with partition projection over `dt` and `hour`. Counting release downloads over a month scans only that month.

```sql
SELECT service, count(*) AS hits, sum(attributes.network.bytes_written) AS bytes
FROM ruby_lang_logs.fastly
WHERE dt BETWEEN '20260801' AND '20260831'
GROUP BY service
```

Objects already in `ftp.r-l.o.log` are untouched. Only new writes stopped.
