### PR TITLE
Drop the shield-side Datadog line from every CDN service

### DIFF
--- a/cdn/README.md
+++ b/cdn/README.md
@@ -4,6 +4,8 @@ Terraform configuration for the Fastly services of ruby-lang.org. Each service l
 
 Datadog is the only log sink. Long term storage of the same events runs through Datadog's S3 log archive, managed in `datadog/`, because the index retention this org's contract allows is 15 days.
 
+Every service shields, and a miss at the edge runs the logging endpoint again at the shield, so each `logging_datadog` block carries a `not-shield-request` response condition of `!req.http.Fastly-FF` to drop the shield line. Without it, a shielded request was counted twice and its `bytes_written` summed twice, which was 30 percent of the events and 24 percent of the bytes. Note that `cache-dev` shields through the `cache` service rather than through itself, because its `default_host` is the shielding domain declared on `cache`, so the condition on `cache` is what drops its shield lines.
+
 The `ftp` service has been dormant since 2018 and is kept with `activate = false`. `ftp.ruby-lang.org` is actually served by the `cache` service.
 
 The `logs.rubyci.org` service fronts the public `rubyci` S3 bucket (chkbuild logs). Switching rubyci.org log links over to it happens in the ruby/rubyci repository.

--- a/cdn/archive.tf
+++ b/cdn/archive.tf
@@ -28,6 +28,18 @@ resource "fastly_service_vcl" "archive" {
     weight                = 100
   }
 
+  # A shielded miss runs the logging endpoint at both POPs, so one request
+  # becomes two events carrying the same byte count. The edge sets Fastly-FF when
+  # it forwards to the shield, so this keeps the edge line, which is the one with
+  # the client POP and the client-facing byte count. This service has no custom
+  # VCL, and a condition keeps it that way.
+  condition {
+    name      = "not-shield-request"
+    priority  = 10
+    statement = "!req.http.Fastly-FF"
+    type      = "RESPONSE"
+  }
+
   domain {
     name = "archive.ruby-lang.org"
   }
@@ -49,11 +61,12 @@ resource "fastly_service_vcl" "archive" {
   }
 
   logging_datadog {
-    format            = file("${path.module}/logging/datadog_format.json")
-    format_version    = 2
-    name              = "Datadog"
-    processing_region = "none"
-    region            = "AP1"
-    token             = var.datadog_token
+    format             = file("${path.module}/logging/datadog_format.json")
+    format_version     = 2
+    name               = "Datadog"
+    processing_region  = "none"
+    region             = "AP1"
+    response_condition = "not-shield-request"
+    token              = var.datadog_token
   }
 }

--- a/cdn/cache.tf
+++ b/cdn/cache.tf
@@ -76,6 +76,19 @@ resource "fastly_service_vcl" "cache" {
     weight                = 100
   }
 
+  # A shielded miss runs the logging endpoint at both POPs, so one request
+  # becomes two events carrying the same byte count. The edge sets Fastly-FF when
+  # it forwards to the shield, so this keeps the edge line, which is the one with
+  # the client POP and the client-facing byte count. cache-dev shields through
+  # this service too, since its default_host is the shielding domain below, so
+  # this drops the cache-dev shield lines as well.
+  condition {
+    name      = "not-shield-request"
+    priority  = 10
+    statement = "!req.http.Fastly-FF"
+    type      = "RESPONSE"
+  }
+
   # Replaces the always_false placeholder that used to keep this backend out of
   # the generated selection. Routing through a condition instead of assigning
   # req.backend in custom VCL is what lets the shield apply. The flag is set
@@ -109,12 +122,13 @@ resource "fastly_service_vcl" "cache" {
   }
 
   logging_datadog {
-    format            = file("${path.module}/logging/datadog_format.json")
-    format_version    = 2
-    name              = "Datadog"
-    processing_region = "none"
-    region            = "AP1"
-    token             = var.datadog_token
+    format             = file("${path.module}/logging/datadog_format.json")
+    format_version     = 2
+    name               = "Datadog"
+    processing_region  = "none"
+    region             = "AP1"
+    response_condition = "not-shield-request"
+    token              = var.datadog_token
   }
 
   # The direct S3 sink is gone. It was this service only, in common log format,

--- a/cdn/cache_dev.tf
+++ b/cdn/cache_dev.tf
@@ -76,6 +76,17 @@ resource "fastly_service_vcl" "cache_dev" {
     weight                = 100
   }
 
+  # A shielded miss runs the logging endpoint at both POPs, so one request
+  # becomes two events carrying the same byte count. The edge sets Fastly-FF when
+  # it forwards to the shield, so this keeps the edge line, which is the one with
+  # the client POP and the client-facing byte count.
+  condition {
+    name      = "not-shield-request"
+    priority  = 10
+    statement = "!req.http.Fastly-FF"
+    type      = "RESPONSE"
+  }
+
   # Replaces the always_false placeholder that used to keep this backend out of
   # the generated selection. Routing through a condition instead of assigning
   # req.backend in custom VCL is what lets the shield apply. The flag is set
@@ -103,12 +114,13 @@ resource "fastly_service_vcl" "cache_dev" {
   }
 
   logging_datadog {
-    format            = file("${path.module}/logging/datadog_format.json")
-    format_version    = 2
-    name              = "Datadog"
-    processing_region = "none"
-    region            = "AP1"
-    token             = var.datadog_token
+    format             = file("${path.module}/logging/datadog_format.json")
+    format_version     = 2
+    name               = "Datadog"
+    processing_region  = "none"
+    region             = "AP1"
+    response_condition = "not-shield-request"
+    token              = var.datadog_token
   }
 
   # Shared with the cache service again now that production runs the same VCL.

--- a/cdn/docs.tf
+++ b/cdn/docs.tf
@@ -28,6 +28,18 @@ resource "fastly_service_vcl" "docs" {
     weight                = 100
   }
 
+  # A shielded miss runs the logging endpoint at both POPs, so one request
+  # becomes two events carrying the same byte count. The edge sets Fastly-FF when
+  # it forwards to the shield, so this keeps the edge line, which is the one with
+  # the client POP and the client-facing byte count. This service has no custom
+  # VCL, and a condition keeps it that way.
+  condition {
+    name      = "not-shield-request"
+    priority  = 10
+    statement = "!req.http.Fastly-FF"
+    type      = "RESPONSE"
+  }
+
   domain {
     name = "docs.ruby-lang.org"
   }
@@ -39,12 +51,13 @@ resource "fastly_service_vcl" "docs" {
   }
 
   logging_datadog {
-    format            = file("${path.module}/logging/datadog_format.json")
-    format_version    = 2
-    name              = "Datadog"
-    processing_region = "none"
-    region            = "AP1"
-    token             = var.datadog_token
+    format             = file("${path.module}/logging/datadog_format.json")
+    format_version     = 2
+    name               = "Datadog"
+    processing_region  = "none"
+    region             = "AP1"
+    response_condition = "not-shield-request"
+    token              = var.datadog_token
   }
 
   request_setting {

--- a/cdn/docs_dev.tf
+++ b/cdn/docs_dev.tf
@@ -28,6 +28,17 @@ resource "fastly_service_vcl" "docs_dev" {
     weight                = 100
   }
 
+  # A shielded miss runs the logging endpoint at both POPs, so one request
+  # becomes two events carrying the same byte count. The edge sets Fastly-FF when
+  # it forwards to the shield, so this keeps the edge line, which is the one with
+  # the client POP and the client-facing byte count.
+  condition {
+    name      = "not-shield-request"
+    priority  = 10
+    statement = "!req.http.Fastly-FF"
+    type      = "RESPONSE"
+  }
+
   # Reached only through the Fastly-provided domain, same as cache-dev. That
   # needs neither a ruby-lang.org zone change nor a TLS subscription, since the
   # shared certificate already covers it.
@@ -42,12 +53,13 @@ resource "fastly_service_vcl" "docs_dev" {
   }
 
   logging_datadog {
-    format            = file("${path.module}/logging/datadog_format.json")
-    format_version    = 2
-    name              = "Datadog"
-    processing_region = "none"
-    region            = "AP1"
-    token             = var.datadog_token
+    format             = file("${path.module}/logging/datadog_format.json")
+    format_version     = 2
+    name               = "Datadog"
+    processing_region  = "none"
+    region             = "AP1"
+    response_condition = "not-shield-request"
+    token              = var.datadog_token
   }
 
   request_setting {

--- a/cdn/logs_rubyci.tf
+++ b/cdn/logs_rubyci.tf
@@ -32,17 +32,29 @@ resource "fastly_service_vcl" "logs_rubyci" {
     weight                = 100
   }
 
+  # A shielded miss runs the logging endpoint at both POPs, so one request
+  # becomes two events carrying the same byte count. The edge sets Fastly-FF when
+  # it forwards to the shield, so this keeps the edge line, which is the one with
+  # the client POP and the client-facing byte count.
+  condition {
+    name      = "not-shield-request"
+    priority  = 10
+    statement = "!req.http.Fastly-FF"
+    type      = "RESPONSE"
+  }
+
   domain {
     name = "logs.rubyci.org"
   }
 
   logging_datadog {
-    format            = file("${path.module}/logging/datadog_format.json")
-    format_version    = 2
-    name              = "Datadog"
-    processing_region = "none"
-    region            = "AP1"
-    token             = var.datadog_token
+    format             = file("${path.module}/logging/datadog_format.json")
+    format_version     = 2
+    name               = "Datadog"
+    processing_region  = "none"
+    region             = "AP1"
+    response_condition = "not-shield-request"
+    token              = var.datadog_token
   }
 
   request_setting {


### PR DESCRIPTION
Every Fastly service in `cdn/` shields, so a request that misses at the edge runs the logging endpoint again at the shield. One user request became two Datadog events carrying the same `bytes_written`, so request counts and byte sums were wrong in both the index and the S3 archive. Over 24 hours that was 30 percent of all events and 24 percent of the summed bytes.

Each `logging_datadog` block now carries a `not-shield-request` response condition of `!req.http.Fastly-FF`, the header the edge sets when it forwards to the shield. A condition keeps this in Terraform, since `docs.tf` and `archive.tf` have no custom VCL.

I confirmed the pairs are the same request before dropping either side, and applied to `cache-dev` and `docs-dev` before production. Shield lines are now zero and edge lines still flow. One surprise is that `cache-dev` shields through the `cache` service, since its `default_host` is the shielding domain declared there.
