### PR TITLE
Add swap and keep the DHCP address on the crossruby host

### DIFF
--- a/recipes/crossruby.rb
+++ b/recipes/crossruby.rb
@@ -21,6 +21,25 @@ execute 'register /swapfile in /etc/fstab' do
   not_if 'grep -q "^/swapfile " /etc/fstab'
 end
 
+# Second line of defense: if a DHCPv4 renewal fails again anyway, keep the
+# leased address instead of tearing ens5 down. netplan cannot express
+# KeepConfiguration, so drop in an override for its generated
+# /run/systemd/network/10-netplan-ens5.network.
+directory '/etc/systemd/network/10-netplan-ens5.network.d' do
+  mode '755'
+end
+
+file '/etc/systemd/network/10-netplan-ens5.network.d/keep-configuration.conf' do
+  mode '644'
+  content "[Network]\nKeepConfiguration=dhcp\n"
+  notifies :run, 'execute[reload systemd-networkd]'
+end
+
+execute 'reload systemd-networkd' do
+  command 'networkctl reload'
+  action :nothing
+end
+
 # start-cross-rubyci probes each cross compiler with Util.search_command and
 # skips targets whose compiler is missing, so this list is what makes the
 # linux/mingw targets actually build. mips (big-endian) and s390 are also

--- a/recipes/crossruby.rb
+++ b/recipes/crossruby.rb
@@ -3,6 +3,24 @@
 # i.e. the host builds cross targets instead of plain ruby branches.
 # The host is Ubuntu; no other platform is supported here.
 
+# wasm-opt peaks at ~3.4 GB anon RSS while the host has 3.8 GB and no swap.
+# The resulting global OOM thrash has repeatedly stalled systemd-networkd's
+# DHCPv4 renewal, dropping ens5 (and ssh) until a reboot.
+execute 'create /swapfile' do
+  command 'fallocate -l 4G /swapfile && chmod 600 /swapfile && mkswap /swapfile'
+  not_if 'test -e /swapfile'
+end
+
+execute 'enable /swapfile' do
+  command 'swapon /swapfile'
+  not_if 'swapon --show=NAME --noheadings | grep -qx /swapfile'
+end
+
+execute 'register /swapfile in /etc/fstab' do
+  command "echo '/swapfile none swap sw 0 0' >> /etc/fstab"
+  not_if 'grep -q "^/swapfile " /etc/fstab'
+end
+
 # start-cross-rubyci probes each cross compiler with Util.search_command and
 # skips targets whose compiler is missing, so this list is what makes the
 # linux/mingw targets actually build. mips (big-endian) and s390 are also


### PR DESCRIPTION
`crossruby.rubyci.org` intermittently became unreachable over ssh until a manual reboot. The journal shows `wasm-opt` peaking at about 3.4 GB anon RSS on this 3.8 GB host with no swap, so the cross builds triggered a global OOM roughly every 4 hours. During one of these thrash windows `systemd-networkd` failed a DHCPv4 renewal with `Could not set DHCPv4 address: Connection timed out` and put `ens5` into the Failed state, dropping the address while the OS kept running. The same signature appears in the journals of 2026-05-02 and 2026-07-30.

This adds a 4 GB `/swapfile` to absorb the `wasm-opt` peak, and a `KeepConfiguration=dhcp` drop-in over the netplan-generated `.network` file so a failed renewal keeps the leased address. Both are applied to the host and verified idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
