### PR TITLE
Move docs.ruby-lang.org to the S3 backends proven on the canary

### DIFF
--- a/cdn/docs.tf
+++ b/cdn/docs.tf
@@ -7,6 +7,11 @@
 # as the fallback for unflagged requests: normally unused, and a one-line VCL
 # change can send any path back to nginx while the origin server still runs.
 resource "fastly_service_vcl" "docs" {
+  # docs_dev held the shielding domain below until this cutover, and Fastly
+  # only allows a domain on one service: docs_dev must release it before this
+  # service claims it within the same apply. Safe to drop after the cutover.
+  depends_on = [fastly_service_vcl.docs_dev]
+
   activate           = true
   stage              = false
   # A shielded fetch needs a Host that is a domain of this service, so the
@@ -121,7 +126,9 @@ resource "fastly_service_vcl" "docs" {
   # A shielded miss runs the logging endpoint at both POPs, so one request
   # becomes two events carrying the same byte count. The edge sets Fastly-FF when
   # it forwards to the shield, so this keeps the edge line, which is the one with
-  # the client POP and the client-facing byte count.
+  # the client POP and the client-facing byte count. docs-dev shields through
+  # this service too, since its default_host is the shielding domain below, so
+  # this drops the docs-dev shield lines as well.
   condition {
     name      = "not-shield-request"
     priority  = 10

--- a/cdn/docs.tf
+++ b/cdn/docs.tf
@@ -1,6 +1,18 @@
+# docs.ruby-lang.org, served from S3 (aws_s3_bucket.docs in s3.tf) through
+# the shape proven out on the docs-dev canary: the same backends and the same
+# VCL file (vcl/docs.vcl), so the canary keeps exercising exactly what
+# production serves. Backend selection goes through request_conditions on a
+# header flag the custom VCL sets before #FASTLY recv (assigning req.backend
+# in VCL would bypass shielding, see cache.tf). The docs-origin backend stays
+# as the fallback for unflagged requests: normally unused, and a one-line VCL
+# change can send any path back to nginx while the origin server still runs.
 resource "fastly_service_vcl" "docs" {
   activate           = true
   stage              = false
+  # A shielded fetch needs a Host that is a domain of this service, so the
+  # bucket endpoint doubles as default_host and as a domain below, the same
+  # arrangement as cache.tf. The other backends override_host instead.
+  default_host       = "docs.r-l.o.s3.amazonaws.com"
   default_ttl        = 60
   http3              = true
   name               = "docs.ruby-lang.org"
@@ -19,8 +31,10 @@ resource "fastly_service_vcl" "docs" {
     max_lifetime          = 0
     max_use               = 0
     name                  = "docs origin server"
+    override_host         = "docs.ruby-lang.org"
     port                  = 443
     prefer_ipv6           = false
+    request_condition     = "backend-is-origin"
     shield                = "tyo-tokyo-jp"
     ssl_cert_hostname     = "docs-origin.ruby-lang.org"
     ssl_check_cert        = true
@@ -28,11 +42,86 @@ resource "fastly_service_vcl" "docs" {
     weight                = 100
   }
 
+  # The docs bucket: public/ root files, en, ja, and wasm (ruby.wasm binaries
+  # for the RUN button). us-east-1, so shielded near it like the cache
+  # service's S3 backend.
+  backend {
+    address               = "s3.amazonaws.com"
+    auto_loadbalance      = false
+    between_bytes_timeout = 10000
+    connect_timeout       = 1000
+    error_threshold       = 0
+    first_byte_timeout    = 15000
+    keepalive_time        = 0
+    max_conn              = 200
+    max_lifetime          = 0
+    max_use               = 0
+    name                  = "s3-docs"
+    port                  = 443
+    prefer_ipv6           = false
+    request_condition     = "backend-is-docs-s3"
+    shield                = "iad-va-us"
+    ssl_cert_hostname     = "s3.amazonaws.com"
+    ssl_check_cert        = true
+    use_ssl               = true
+    weight                = 100
+  }
+
+  # Doxygen stays in the rubyci bucket for now (step 1 of the migration);
+  # dropping this backend and pointing doxygen.yml at the docs bucket's
+  # capi/en/master/ prefix is step 2. The bucket name has no dots, so the
+  # virtual-hosted endpoint works as the TLS hostname directly, the same
+  # arrangement as logs_rubyci.tf. override_host is required: default_host
+  # rewrites Host to the docs bucket endpoint, and S3 routes by Host, so
+  # without it these requests would hit the docs bucket. Unshielded:
+  # it refreshes every three hours and carries little traffic.
+  backend {
+    address               = "rubyci.s3.ap-northeast-1.amazonaws.com"
+    auto_loadbalance      = false
+    between_bytes_timeout = 10000
+    connect_timeout       = 1000
+    error_threshold       = 0
+    first_byte_timeout    = 15000
+    keepalive_time        = 0
+    max_conn              = 200
+    max_lifetime          = 0
+    max_use               = 0
+    name                  = "s3-rubyci-doxygen"
+    override_host         = "rubyci.s3.ap-northeast-1.amazonaws.com"
+    port                  = 443
+    prefer_ipv6           = false
+    request_condition     = "backend-is-doxygen-s3"
+    ssl_cert_hostname     = "rubyci.s3.ap-northeast-1.amazonaws.com"
+    ssl_check_cert        = true
+    use_ssl               = true
+    weight                = 100
+  }
+
+  condition {
+    name      = "backend-is-origin"
+    priority  = 10
+    statement = "!req.http.X-Docs-Backend"
+    type      = "REQUEST"
+  }
+
+  condition {
+    name      = "backend-is-docs-s3"
+    priority  = 10
+    statement = "req.http.X-Docs-Backend == \"s3\""
+    type      = "REQUEST"
+  }
+
+  condition {
+    name      = "backend-is-doxygen-s3"
+    priority  = 10
+    statement = "req.http.X-Docs-Backend == \"doxygen\""
+    type      = "REQUEST"
+  }
+
   # A shielded miss runs the logging endpoint at both POPs, so one request
   # becomes two events carrying the same byte count. The edge sets Fastly-FF when
   # it forwards to the shield, so this keeps the edge line, which is the one with
-  # the client POP and the client-facing byte count. This service has no custom
-  # VCL, and a condition keeps it that way.
+  # the client POP and the client-facing byte count.
   condition {
     name      = "not-shield-request"
     priority  = 10
@@ -40,13 +129,25 @@ resource "fastly_service_vcl" "docs" {
     type      = "RESPONSE"
   }
 
+  # What /ja/latest and /ja/master resolve to (the bucket holds no symlink
+  # objects), and what the unreleased-version redirects key off. A release
+  # updates these values and everything else follows.
+  dictionary {
+    name = "docs_versions"
+  }
+
   domain {
     name = "docs.ruby-lang.org"
   }
 
+  domain {
+    comment = "For shielding"
+    name    = "docs.r-l.o.s3.amazonaws.com"
+  }
+
   gzip {
-    content_types = ["text/html", "application/x-javascript", "text/css", "application/javascript", "text/javascript", "application/json", "application/vnd.ms-fontobject", "application/x-font-opentype", "application/x-font-truetype", "application/x-font-ttf", "application/xml", "font/eot", "font/opentype", "font/otf", "image/svg+xml", "image/vnd.microsoft.icon", "text/plain", "text/xml"]
-    extensions    = ["css", "js", "html", "eot", "ico", "otf", "ttf", "json", "svg"]
+    content_types = ["text/html", "application/x-javascript", "text/css", "application/javascript", "text/javascript", "application/json", "application/vnd.ms-fontobject", "application/x-font-opentype", "application/x-font-truetype", "application/x-font-ttf", "application/xml", "font/eot", "font/opentype", "font/otf", "image/svg+xml", "image/vnd.microsoft.icon", "text/plain", "text/xml", "text/markdown"]
+    extensions    = ["css", "js", "html", "eot", "ico", "otf", "ttf", "json", "svg", "md", "xml", "txt"]
     name          = "Default Gzip Policy"
   }
 
@@ -68,5 +169,23 @@ resource "fastly_service_vcl" "docs" {
     name             = "Force TLS"
     timer_support    = false
     xff              = "append"
+  }
+
+  vcl {
+    content = file("${path.module}/vcl/docs.vcl")
+    main    = true
+    name    = "default"
+  }
+}
+
+# The same values as docs_dev_versions; a release updates both (manage_items
+# stays false, so out-of-band dictionary updates are not reverted by plan).
+resource "fastly_service_dictionary_items" "docs_versions" {
+  service_id    = fastly_service_vcl.docs.id
+  dictionary_id = one([for d in fastly_service_vcl.docs.dictionary : d.dictionary_id if d.name == "docs_versions"])
+
+  items = {
+    latest = "4.0"
+    master = "4.1"
   }
 }

--- a/cdn/docs.tf
+++ b/cdn/docs.tf
@@ -178,11 +178,15 @@ resource "fastly_service_vcl" "docs" {
   }
 }
 
-# The same values as docs_dev_versions; a release updates both (manage_items
-# stays false, so out-of-band dictionary updates are not reverted by plan).
+# The same values as docs_dev_versions; a release updates both dictionaries
+# out of band (API/UI). manage_items=false (the provider default, explicit
+# here) opts out of reapplying these items when they drift, so a release's
+# update is not reverted by the next apply; these are only the initial
+# values.
 resource "fastly_service_dictionary_items" "docs_versions" {
   service_id    = fastly_service_vcl.docs.id
   dictionary_id = one([for d in fastly_service_vcl.docs.dictionary : d.dictionary_id if d.name == "docs_versions"])
+  manage_items  = false
 
   items = {
     latest = "4.0"

--- a/cdn/docs_dev.tf
+++ b/cdn/docs_dev.tf
@@ -1,9 +1,10 @@
-# The S3-backend canary for docs.ruby-lang.org. The production service keeps
-# pointing at docs-origin until this proves out, then docs.tf adopts the same
-# shape. Backend selection goes through request_conditions on a header flag the
-# custom VCL sets before #FASTLY recv (assigning req.backend in VCL would
-# bypass shielding, see cache.tf); the docs-origin backend stays as the
-# fallback for unflagged requests so paths can be moved over one at a time.
+# The S3-backend canary for docs.ruby-lang.org: the same backends and the
+# same VCL file as docs.tf, on a Fastly-provided domain, so a VCL or backend
+# change can be applied and probed here before docs.tf picks it up. Backend
+# selection goes through request_conditions on a header flag the custom VCL
+# sets before #FASTLY recv (assigning req.backend in VCL would bypass
+# shielding, see cache.tf); the docs-origin backend stays as the fallback
+# for unflagged requests so paths could be moved back one at a time.
 resource "fastly_service_vcl" "docs_dev" {
   activate           = true
   stage              = false
@@ -172,7 +173,7 @@ resource "fastly_service_vcl" "docs_dev" {
   }
 
   vcl {
-    content = file("${path.module}/vcl/docs_dev.vcl")
+    content = file("${path.module}/vcl/docs.vcl")
     main    = true
     name    = "default"
   }

--- a/cdn/docs_dev.tf
+++ b/cdn/docs_dev.tf
@@ -8,9 +8,11 @@
 resource "fastly_service_vcl" "docs_dev" {
   activate           = true
   stage              = false
-  # A shielded fetch needs a Host that is a domain of this service, so the
-  # bucket endpoint doubles as default_host and as a domain below, the same
-  # arrangement as cache.tf. The other backends override_host instead.
+  # A shielded fetch needs a Host that is a domain of some service, and a
+  # domain can only be attached to one: docs.tf owns the bucket endpoint, so
+  # a shielded fetch from here enters the docs service at the shield POP,
+  # the same arrangement as cache_dev.tf through cache.tf. The other
+  # backends override_host instead.
   default_host       = "docs.r-l.o.s3.amazonaws.com"
   default_ttl        = 60
   http3              = true
@@ -132,11 +134,6 @@ resource "fastly_service_vcl" "docs_dev" {
   # updates these values and everything else follows.
   dictionary {
     name = "docs_versions"
-  }
-
-  domain {
-    comment = "For shielding"
-    name    = "docs.r-l.o.s3.amazonaws.com"
   }
 
   # Reached only through the Fastly-provided domain, same as cache-dev. That

--- a/cdn/docs_dev.tf
+++ b/cdn/docs_dev.tf
@@ -182,6 +182,7 @@ resource "fastly_service_vcl" "docs_dev" {
 resource "fastly_service_dictionary_items" "docs_dev_versions" {
   service_id    = fastly_service_vcl.docs_dev.id
   dictionary_id = one([for d in fastly_service_vcl.docs_dev.dictionary : d.dictionary_id if d.name == "docs_versions"])
+  manage_items  = false
 
   items = {
     latest = "4.0"

--- a/cdn/iam.tf
+++ b/cdn/iam.tf
@@ -24,23 +24,25 @@ resource "aws_iam_openid_connect_provider" "github" {
 locals {
   docs_bucket_arn = "arn:aws:s3:::docs.r-l.o"
 
-  # role key => which repository ref may assume it, and which object
+  # role key => which repository refs may assume it, and which object
   # prefixes it may write. "*" means the whole bucket.
   docs_sync_repos = {
     ruby-actions = {
-      sub      = "repo:ruby/actions:ref:refs/heads/master"
+      subs     = ["repo:ruby/actions:ref:refs/heads/master"]
       prefixes = ["en/*", "capi/*"]
     }
     generated-documents = {
-      sub      = "repo:rurema/generated-documents:ref:refs/heads/main"
+      subs     = ["repo:rurema/generated-documents:ref:refs/heads/main"]
       prefixes = ["ja/*"]
     }
     docs-ruby-lang-org = {
-      sub      = "repo:ruby/docs.ruby-lang.org:ref:refs/heads/master"
+      subs     = ["repo:ruby/docs.ruby-lang.org:ref:refs/heads/master"]
       prefixes = ["*"]
     }
     run-ruby-wasm = {
-      sub      = "repo:rurema/run-ruby-wasm:ref:refs/heads/main"
+      # The binaries are cut as GitHub Releases, so a release-triggered sync
+      # workflow presents a tag ref, not the branch.
+      subs     = ["repo:rurema/run-ruby-wasm:ref:refs/heads/main", "repo:rurema/run-ruby-wasm:ref:refs/tags/*"]
       prefixes = ["wasm/*"]
     }
   }
@@ -63,7 +65,11 @@ resource "aws_iam_role" "docs_sync" {
         Condition = {
           StringEquals = {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-            "token.actions.githubusercontent.com:sub" = each.value.sub
+          }
+          # StringLike so the tag-ref entries can carry a wildcard; entries
+          # without one still match exactly.
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = each.value.subs
           }
         }
       },

--- a/cdn/iam.tf
+++ b/cdn/iam.tf
@@ -1,0 +1,114 @@
+# GitHub Actions OIDC roles for uploading to the docs bucket. Each producing
+# repository assumes its own role, restricted to the prefix it owns, so the
+# long-lived access keys the current server-side pipelines use are not
+# reproduced here:
+#
+#   ruby/actions              en/* and capi/*   (rdoc; doxygen once it moves)
+#   rurema/generated-documents ja/*             (bitclust HTML, daily)
+#   ruby/docs.ruby-lang.org   whole bucket      (site chrome: root files plus
+#                                                the en/ja version indexes)
+#   rurema/run-ruby-wasm      wasm/*            (ruby.wasm for the RUN button)
+#
+# If the account already has the GitHub OIDC provider, import it instead of
+# letting apply fail with EntityAlreadyExists:
+#   terraform import aws_iam_openid_connect_provider.github \
+#     arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # AWS validates GitHub's issuer against its own trusted CA store and
+  # ignores the thumbprint for this provider, but the API requires one.
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+locals {
+  docs_bucket_arn = "arn:aws:s3:::docs.r-l.o"
+
+  # role key => which repository ref may assume it, and which object
+  # prefixes it may write. "*" means the whole bucket.
+  docs_sync_repos = {
+    ruby-actions = {
+      sub      = "repo:ruby/actions:ref:refs/heads/master"
+      prefixes = ["en/*", "capi/*"]
+    }
+    generated-documents = {
+      sub      = "repo:rurema/generated-documents:ref:refs/heads/main"
+      prefixes = ["ja/*"]
+    }
+    docs-ruby-lang-org = {
+      sub      = "repo:ruby/docs.ruby-lang.org:ref:refs/heads/master"
+      prefixes = ["*"]
+    }
+    run-ruby-wasm = {
+      sub      = "repo:rurema/run-ruby-wasm:ref:refs/heads/main"
+      prefixes = ["wasm/*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "docs_sync" {
+  for_each = local.docs_sync_repos
+
+  name = "docs-sync-${each.key}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = each.value.sub
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "docs_sync" {
+  for_each = local.docs_sync_repos
+
+  name = "docs-sync-${each.key}"
+  role = aws_iam_role.docs_sync[each.key].id
+
+  # ListBucket is what lets `aws s3 sync` diff before uploading; the prefix
+  # condition keeps each role from listing outside its own area. For "*"
+  # roles the allowed prefixes are "" and "*": an unprefixed listing is
+  # evaluated as the empty prefix, which a bare "*" alone would not cover.
+  # DeleteObject is for `sync --delete`.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "List"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [local.docs_bucket_arn]
+        Condition = {
+          StringLike = {
+            "s3:prefix" = contains(each.value.prefixes, "*") ? ["", "*"] : flatten([for p in each.value.prefixes : [trimsuffix(p, "/*"), p]])
+          }
+        }
+      },
+      {
+        Sid    = "Write"
+        Effect = "Allow"
+        Action = ["s3:PutObject", "s3:DeleteObject"]
+        Resource = [
+          for p in each.value.prefixes : "${local.docs_bucket_arn}/${p}"
+        ]
+      },
+    ]
+  })
+}
+
+output "docs_sync_role_arns" {
+  description = "Pass to aws-actions/configure-aws-credentials (role-to-assume) in each repository's sync workflow"
+  value       = { for k, r in aws_iam_role.docs_sync : k => r.arn }
+}

--- a/cdn/vcl/docs.vcl
+++ b/cdn/vcl/docs.vcl
@@ -281,7 +281,8 @@ sub vcl_fetch {
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {
-    # apply the default ttl, which must match default_ttl in docs_dev.tf
+    # apply the default ttl, which must match default_ttl in docs.tf and
+    # docs_dev.tf
     set beresp.ttl = 60s;
   }
 

--- a/cdn/vcl/docs.vcl
+++ b/cdn/vcl/docs.vcl
@@ -1,6 +1,8 @@
 sub vcl_recv {
 
-  # ---- S3 backend routing and rewrites (docs-dev canary) ----
+  # ---- S3 backend routing and rewrites ----
+  # Shared by docs.tf (production) and docs_dev.tf (canary), so the canary
+  # always exercises exactly the VCL that production serves.
   # Runs before #FASTLY recv so the generated backend-selection code
   # (request_condition) can see the X-Docs-Backend flag, same as cache.vcl.
   # Client-visible URLs never change here: everything except the synthetic
@@ -239,6 +241,10 @@ sub vcl_fetch {
       if (req.http.X-Docs-Symlink) {
         set beresp.http.Surrogate-Key = beresp.http.Surrogate-Key " ja/" req.http.X-Docs-Symlink;
       }
+    } else if (req.url ~ "^/wasm/") {
+      # ruby.wasm binaries for the RUN button (rurema/run-ruby-wasm releases,
+      # synced to the wasm/ prefix). Same-origin, so no CORS setup is needed.
+      set beresp.http.Surrogate-Key = "wasm";
     } else {
       set beresp.http.Surrogate-Key = "index";
     }


### PR DESCRIPTION
Cuts docs.ruby-lang.org production over to the S3 backends in **one apply**, now that the docs-dev canary has passed the whole testing checklist (see #72). Branched on top of #72, so this is the same tree you last applied plus one commit.

## What changes

- **cdn/docs.tf** adopts the canary shape: the three backends behind `request_condition`s, the `docs_versions` dictionary (+items `latest=4.0` / `master=4.1`), the bucket endpoint as `default_host` plus a shielding domain, gzip entries for markdown/xml/txt, and the shared custom VCL. The service is updated in place (`name` unchanged, `domain docs.ruby-lang.org` unchanged) — no DNS or TLS work.
- **One shared VCL**: `vcl/docs_dev.vcl` → `vcl/docs.vcl`, referenced by both services, so the canary always exercises exactly what production serves. The only content change is a `Surrogate-Key: wasm` for the new prefix.
- **`wasm/` prefix**: rurema/run-ruby-wasm's ruby.wasm binaries (the RUN button runtime) move onto the docs bucket — same-origin loading, no CORS, no third-party CDN.
- **cdn/iam.tf**: GitHub Actions OIDC provider + four upload roles, one per producing repository, each restricted to its own prefix (`ruby/actions`: `en/* capi/*`, `rurema/generated-documents`: `ja/*`, `ruby/docs.ruby-lang.org`: whole bucket for the site chrome, `rurema/run-ruby-wasm`: `wasm/*`). Role ARNs come out as an output for the repository-side sync workflows.
  - **If the account already has the GitHub OIDC provider**, import it first (the file has the exact command in a comment); otherwise apply creates it.

## Rollback / safety

- The docs-origin backend stays as the normally-unused fallback (`!req.http.X-Docs-Backend`), and nginx keeps running untouched. Any path can be sent back to origin with a one-line VCL change; full rollback is a revert of this commit plus one apply.
- The `fastly-purge-key` Surrogate-Key scheme is unchanged, so the existing server-side purges keep working during the transition.

## Before apply (we handle this, no infra action)

The bucket must hold the full content set; `ja/4.0` and the site root are already loaded from the canary test. We are loading the rest (all `ja` versions from generated-documents, `en` from the `ruby-docs-en-*.tar.xz` tarballs, wasm release) and will confirm here when done — **please apply after that confirmation**. As with #72, apply with the real `datadog_token`.

Expected plan: the docs service as an in-place change, adds for the dictionary items + OIDC provider + 4 roles + 4 role policies, 0 destroys.

## After apply

We re-run the #72 testing checklist against production and watch the Datadog logs. Follow-ups that need no infra action: per-repository sync workflows (using the role ARNs), pointing the RUN button at `/wasm/`, and later retiring the server-side pipelines; dropping the docs-origin backend and moving doxygen into the bucket (`capi/en/master/`) come as a separate cleanup once things have settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
