### PR TITLE
Allow docs-sync sessions up to 6 hours

### DIFF
--- a/cdn/iam.tf
+++ b/cdn/iam.tf
@@ -53,6 +53,12 @@ resource "aws_iam_role" "docs_sync" {
 
   name = "docs-sync-${each.key}"
 
+  # A full re-upload of html/ja (site-wide regeneration days) runs longer
+  # than the default 1-hour session and dies with ExpiredToken mid-sync.
+  # Allow the workflows to request up to 6 hours (the GitHub-hosted job
+  # limit); normal incremental runs still use a short session.
+  max_session_duration = 21600
+
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [


### PR DESCRIPTION
Raise `max_session_duration` on the docs-sync roles to 21600 seconds (6 hours, the GitHub-hosted job limit).

The initial full upload of `html/ja` died exactly at the 1-hour mark with `ExpiredToken` ([rurema/generated-documents run 32343869053](https://github.com/rurema/generated-documents/actions/runs/32343869053)): `configure-aws-credentials` issues a 1-hour session by default, and the roles cap `MaxSessionDuration` at the same default. Site-wide regeneration days (template changes) re-upload most of the ~270k objects and can run long.

With the concurrency bump on the workflow side a full upload now fits in well under an hour, so this is a safety margin rather than a hard requirement; the workflows opt in per-run with `role-duration-seconds`, and normal incremental runs keep using short sessions.

**Please apply when convenient** — applying together with #75 would make it a single round.

---

(日本語) docs-sync ロールのセッション上限を 6 時間へ。初回フル sync が既定 1 時間のセッション期限ちょうどで ExpiredToken になった件の保険です。並列度引き上げ後はフルでも 1 時間内に収まるため必須ではありません。#75 とまとめて apply いただけると 1 回で済みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
