### PR TITLE
Use the immutable sub claim for the run-ruby-wasm role

### DIFF
--- a/cdn/iam.tf
+++ b/cdn/iam.tf
@@ -26,6 +26,12 @@ locals {
 
   # role key => which repository refs may assume it, and which object
   # prefixes it may write. "*" means the whole bucket.
+  #
+  # Repositories created (or renamed) after 2026-07-15 present the immutable
+  # sub claim, which embeds the owner and repository ids:
+  # "repo:OWNER@OWNER-ID/REPO@REPO-ID:ref:..." — the ids are shown at the
+  # repository's /settings/actions/oidc-configuration page. Older
+  # repositories keep the classic "repo:OWNER/REPO:ref:..." form.
   docs_sync_repos = {
     ruby-actions = {
       subs     = ["repo:ruby/actions:ref:refs/heads/master"]
@@ -41,8 +47,13 @@ locals {
     }
     run-ruby-wasm = {
       # The binaries are cut as GitHub Releases, so a release-triggered sync
-      # workflow presents a tag ref, not the branch.
-      subs     = ["repo:rurema/run-ruby-wasm:ref:refs/heads/main", "repo:rurema/run-ruby-wasm:ref:refs/tags/*"]
+      # workflow presents a tag ref, not the branch. Created 2026-08-16, so
+      # the sub is the immutable form (rurema = 4122513,
+      # run-ruby-wasm = 1335558093).
+      subs = [
+        "repo:rurema@4122513/run-ruby-wasm@1335558093:ref:refs/heads/main",
+        "repo:rurema@4122513/run-ruby-wasm@1335558093:ref:refs/tags/*",
+      ]
       prefixes = ["wasm/*"]
     }
   }


### PR DESCRIPTION
Fix the trust policy of the `docs-sync-run-ruby-wasm` role: the sync workflow in rurema/run-ruby-wasm fails to assume it with `Not authorized to perform sts:AssumeRoleWithWebIdentity` ([failed run](https://github.com/rurema/run-ruby-wasm/actions/runs/32376841633)).

rurema/run-ruby-wasm was created on 2026-08-16, after GitHub's 2026-07-15 cutoff, so its OIDC tokens carry the [immutable subject claim](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims) — `repo:OWNER@OWNER-ID/REPO@REPO-ID:ref:...` — and this cannot be turned off in the repository settings. The classic `repo:rurema/run-ruby-wasm:ref:...` condition therefore never matches.

This switches the two `sub` entries (main branch and release tags) to the immutable form. The ids (rurema = 4122513, run-ruby-wasm = 1335558093) are taken from the repository's OIDC configuration page and cross-checked against the API. The other three repositories predate the cutoff and keep the classic form; a comment now warns about the cutoff for future additions.

**Please apply when convenient** — applying together with #74 would make it a single round. After the apply we will re-run the sync with the existing release tag to verify.

---

(日本語) run-ruby-wasm は 2026-07-15 カットオフ後の作成のため immutable subject claims が強制され、従来形式の trust に一致せず AssumeRole が拒否されていました。sub 2 エントリを immutable 形式へ差し替えます。#74 とまとめて apply いただけると 1 回で済みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
