### PR TITLE
Bypass the cache for /pub/tmp on cache.ruby-lang.org

### DIFF
--- a/cdn/vcl/cache.vcl
+++ b/cdn/vcl/cache.vcl
@@ -26,6 +26,13 @@ sub vcl_recv {
     return(pass);
   }
 
+  // /pub/tmp holds experimental files that are replaced in place, so serving
+  // them from cache returns stale content. Without this, vcl_fetch pins S3
+  // objects for a year based on ETag.
+  if (req.url ~ "^/pub/tmp(/|$)") {
+    return(pass);
+  }
+
   return(lookup);
 }
 


### PR DESCRIPTION
`/pub/tmp` on `cache.ruby-lang.org` is a scratch area whose files are replaced in place, but `vcl_fetch` pins S3 objects for a year based on their ETag, so updated files kept serving stale content. This adds a `return(pass)` for `^/pub/tmp(/|$)` in `vcl_recv` so requests bypass the cache at both the edge and the shield. The VCL is shared with `cache-dev`, so I applied and verified there first. Both services are applied and repeated requests to `/pub/tmp/` now return `x-cache: MISS, MISS`.

Generated with [Claude Code](https://claude.com/claude-code)
