### PR TITLE
Retire the docs-origin backend

### DIFF
--- a/cdn/docs.tf
+++ b/cdn/docs.tf
@@ -3,9 +3,9 @@
 # VCL file (vcl/docs.vcl), so the canary keeps exercising exactly what
 # production serves. Backend selection goes through request_conditions on a
 # header flag the custom VCL sets before #FASTLY recv (assigning req.backend
-# in VCL would bypass shielding, see cache.tf). The docs-origin backend stays
-# as the fallback for unflagged requests: normally unused, and a one-line VCL
-# change can send any path back to nginx while the origin server still runs.
+# in VCL would bypass shielding, see cache.tf). Every request the VCL lets
+# through is flagged to one of the S3 backends; non-GET/HEAD methods get a
+# synthetic 405 at the edge (the origin server is retired).
 resource "fastly_service_vcl" "docs" {
   # docs_dev held the shielding domain below until this cutover, and Fastly
   # only allows a domain on one service: docs_dev must release it before this
@@ -23,29 +23,6 @@ resource "fastly_service_vcl" "docs" {
   name               = "docs.ruby-lang.org"
   stale_if_error     = true
   stale_if_error_ttl = 43200
-
-  backend {
-    address               = "docs-origin.ruby-lang.org"
-    auto_loadbalance      = false
-    between_bytes_timeout = 10000
-    connect_timeout       = 1000
-    error_threshold       = 0
-    first_byte_timeout    = 15000
-    keepalive_time        = 0
-    max_conn              = 200
-    max_lifetime          = 0
-    max_use               = 0
-    name                  = "docs origin server"
-    override_host         = "docs.ruby-lang.org"
-    port                  = 443
-    prefer_ipv6           = false
-    request_condition     = "backend-is-origin"
-    shield                = "tyo-tokyo-jp"
-    ssl_cert_hostname     = "docs-origin.ruby-lang.org"
-    ssl_check_cert        = true
-    use_ssl               = true
-    weight                = 100
-  }
 
   # The docs bucket: public/ root files, en, ja, and wasm (ruby.wasm binaries
   # for the RUN button). us-east-1, so shielded near it like the cache
@@ -100,13 +77,6 @@ resource "fastly_service_vcl" "docs" {
     ssl_check_cert        = true
     use_ssl               = true
     weight                = 100
-  }
-
-  condition {
-    name      = "backend-is-origin"
-    priority  = 10
-    statement = "!req.http.X-Docs-Backend"
-    type      = "REQUEST"
   }
 
   condition {

--- a/cdn/docs_dev.tf
+++ b/cdn/docs_dev.tf
@@ -3,8 +3,8 @@
 # change can be applied and probed here before docs.tf picks it up. Backend
 # selection goes through request_conditions on a header flag the custom VCL
 # sets before #FASTLY recv (assigning req.backend in VCL would bypass
-# shielding, see cache.tf); the docs-origin backend stays as the fallback
-# for unflagged requests so paths could be moved back one at a time.
+# shielding, see cache.tf); every request the VCL lets through is flagged
+# to one of the S3 backends, and non-GET/HEAD methods get a synthetic 405.
 resource "fastly_service_vcl" "docs_dev" {
   activate           = true
   stage              = false
@@ -19,29 +19,6 @@ resource "fastly_service_vcl" "docs_dev" {
   name               = "docs-dev.ruby-lang.org"
   stale_if_error     = true
   stale_if_error_ttl = 43200
-
-  backend {
-    address               = "docs-origin.ruby-lang.org"
-    auto_loadbalance      = false
-    between_bytes_timeout = 10000
-    connect_timeout       = 1000
-    error_threshold       = 0
-    first_byte_timeout    = 15000
-    keepalive_time        = 0
-    max_conn              = 200
-    max_lifetime          = 0
-    max_use               = 0
-    name                  = "docs origin server"
-    override_host         = "docs.ruby-lang.org"
-    port                  = 443
-    prefer_ipv6           = false
-    request_condition     = "backend-is-origin"
-    shield                = "tyo-tokyo-jp"
-    ssl_cert_hostname     = "docs-origin.ruby-lang.org"
-    ssl_check_cert        = true
-    use_ssl               = true
-    weight                = 100
-  }
 
   # The docs bucket (aws_s3_bucket.docs in s3.tf): public/ root files, en and
   # ja. us-east-1, so shielded near it like the cache service's S3 backend.
@@ -95,13 +72,6 @@ resource "fastly_service_vcl" "docs_dev" {
     ssl_check_cert        = true
     use_ssl               = true
     weight                = 100
-  }
-
-  condition {
-    name      = "backend-is-origin"
-    priority  = 10
-    statement = "!req.http.X-Docs-Backend"
-    type      = "REQUEST"
   }
 
   condition {

--- a/cdn/vcl/docs.vcl
+++ b/cdn/vcl/docs.vcl
@@ -170,16 +170,18 @@ sub vcl_recv {
       set req.http.X-Docs-Backend = "doxygen";
       set req.url = regsub(req.url, "^/capi/en/master/", "/doxygen-latest-html/");
     } else {
-      # Narrow this per prefix to move paths over one at a time; anything
-      # unflagged still goes to docs-origin.
+      # Everything else (root files, en, ja, wasm) lives in the docs bucket.
       set req.http.X-Docs-Backend = "s3";
     }
   }
 
 #FASTLY recv
 
+  # Nothing here serves writes, and the origin server these used to pass
+  # to is retired; answer other methods at the edge. The doc.ruby-lang.org
+  # redirect above still covers every method, like its nginx vhost did.
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
-    return(pass);
+    error 605;
   }
 
   return(lookup);
@@ -336,6 +338,17 @@ sub vcl_error {
     }
     set obj.http.Location = req.http.X-Redirect-Location;
     synthetic "";
+    return(deliver);
+  }
+
+  # Non-GET/HEAD requests (bot POSTs, in practice), no longer passed to
+  # the retired origin server.
+  if (obj.status == 605) {
+    set obj.status = 405;
+    set obj.response = "Method Not Allowed";
+    set obj.http.Allow = "GET, HEAD";
+    set obj.http.Content-Type = "text/html; charset=utf-8";
+    synthetic {"<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Method not allowed.</h1></body></html>"};
     return(deliver);
   }
 

--- a/dns/ruby-lang.org/dnsconfig.js
+++ b/dns/ruby-lang.org/dnsconfig.js
@@ -4,8 +4,6 @@ var REG_NONE = NewRegistrar("none");
 D("ruby-lang.org", REG_NONE,
 	DnsProvider(DSP_CLOUDFLARE),
 	DefaultTTL(1),
-	A("docs-2020", "18.178.72.192"),
-	A("docs-origin", "18.178.72.192"),
 	A("gem-codesearch.dev", "18.180.198.97"),
 	A("git", "52.192.80.219"),
 	A("mame.dev", "18.180.198.97"),


### PR DESCRIPTION
## What

Removes the last ties between the docs Fastly service and the origin server (docs-2020), so the machine can be retired:

- `cdn/docs.tf` / `cdn/docs_dev.tf`: drop the `docs-origin.ruby-lang.org` backend and its `backend-is-origin` condition from both services.
- `cdn/vcl/docs.vcl`: non-GET/HEAD methods used to `return(pass)` to that backend; answer them at the edge with a synthetic `405` + `Allow: GET, HEAD` instead. The `doc.ruby-lang.org` redirect is unaffected (it fires earlier in recv, for every method).
- `dns/ruby-lang.org/dnsconfig.js`: drop the `docs-2020` / `docs-origin` A records.

This deliberately gives up the "one-line VCL change sends paths back to nginx" rollback standby: the origin's content-refresh timers (`update-docs-ja` / `update-docs-en`) were disabled on 2026-08-26, so the copy it holds is frozen at 2026-08-25 and only ages from here.

## Why

After #77 was applied and the DNS flipped (verified from outside: `doc.ruby-lang.org` resolves to the shared Fastly CNAME and the edge answers `301` for every method, query string preserved), nothing live is left on the origin. Today's access log — with the `ff="$http_fastly_ff"` / `host="$host"` fields added after #73 — shows:

- Only 3 of ~4,700 requests came through Fastly (`ff=` set), and all three are WordPress-probe POSTs, i.e. exactly the non-GET/HEAD `return(pass)` path this PR closes.
- The remaining `host="doc.ruby-lang.org"` requests (25) are stragglers from caches of the old A record and will decay.
- Everything else is direct scanner traffic to `docs-origin.ruby-lang.org` (the Let's Encrypt certificate keeps the name in CT logs, which is what draws it) and to the bare IP.

## Apply order

1. `terraform apply` in `cdn/` (both `docs` and `docs_dev` change in place; real `datadog_token` as usual). Apply before the DNS push, so the backend's hostname still resolves while it exists.
2. Verify:

   ```
   curl -sI -X POST https://docs.ruby-lang.org/
   ```

   Expected: `405` with `allow: GET, HEAD` from Varnish.

   ```
   curl -sI https://docs.ruby-lang.org/ja/latest/
   curl -sI https://doc.ruby-lang.org/ja/
   ```

   Expected: unchanged (`200` / `301` to docs).
3. `dnscontrol push` for the ruby-lang.org zone, by hand per `dns/README.md`. After the push the `docs-2020` / `docs-origin` names stop resolving; any remaining maintenance access to the machine can use its IP (18.178.72.192).

## After this lands

Nothing depends on the server anymore: the nginx vhosts serve no live traffic, the sync timers are already disabled, and the certbot renewals for `docs` / `doc` / `docs-origin` become unnecessary with it. The instance itself is not under Terraform (none of the states in `ruby-lang-terraform-state` hold an `aws_instance`, and stop/terminate permission is confirmed by dry-run), so I will stop and later terminate it from the AWS side myself after the DNS push — nothing is needed from you beyond the apply and the push. That closes out the docs.ruby-lang.org S3 migration.

---

(日本語要約)origin サーバー(docs-2020)退役の最終段です。#77 適用+DNS 切替済みを外形実測で確認したうえで、①両サービスから docs-origin backend を撤去し、non-GET/HEAD(実態は WordPress 探索ボットの POST のみ)はエッジの合成 405 で応答 ②docs-2020/docs-origin の A レコードを削除します。コンテンツ同期 timer は 08-26 に停止済みで切り戻し用コピーは古くなる一方のため、nginx への切り戻し経路は意図的に放棄します。適用順= terraform apply → 動作確認 → dnscontrol push(手動)。インスタンス自体は terraform 管理外(state 全数確認済み)で stop/terminate 権限も dry-run で確認済みのため、**push 後の停止・廃棄は znz 側で実施します**。この PR でお願いしたいのは apply と push のみです(certbot はサーバーごと不要になります)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
