### PR TITLE
Stop setting up chkbuild on openbsd.rubyci.org

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -66,7 +66,10 @@ openbsd.rubyci.org:
     nopasswd_sudo: true
     compress: false
     run_list:
-      - recipes/default.rb
+      # chkbuild belongs in the OpenBSD VM on this host, not on the host
+      # itself.
+      - recipes/hostname.rb
+      - recipes/setup-users.rb
 
 ubuntu.rubyci.org:
   properties:


### PR DESCRIPTION
The OpenBSD instance died. We launched a new Ubuntu instance and will redo it with QEMU on top of it, so chkbuild is not set up on the host itself.