### PR TITLE
Build a rubyci host without the web console

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ bin/launch --eip 52.69.117.212 fedora45.rubyci.org ami-0123456789abcdef0 c5a.lar
 
 `--eip new` allocates a new Elastic IP and `--eip <address|allocation id>` takes an existing unassociated one. Either way a `*.rubyci.org` host gets its A record written into `dns/rubyci.org/dnsconfig.js`, and committing that is what applies the zone. Without `--eip` the instance keeps the address its subnet assigns, which is lost on the next stop. The Name tag is `rubyci-<label>`; pass `--name` where that does not hold, as with `riscv.rubyci.org` running on `rubyci-riscv64`.
 
+### Elastic IP swap
+
+Rotating an EOL host out reuses its Elastic IP, which leaves the DNS record alone. Launch the replacement with `bin/launch` and no `--eip`, bootstrap and apply it on the temporary address its subnet assigns, and hand it the host name with `bin/eip-swap` only once it works. The old instance keeps running and loses its public address, so stop or terminate it after the replacement is known good.
+
+```bash
+# report which instance holds the address today, and dry-run the API call
+bin/eip-swap -n debian11.rubyci.org i-0123456789abcdef0
+
+# swap
+bin/eip-swap debian11.rubyci.org i-0123456789abcdef0
+```
+
+The replacement answers on a different host key under the same name, so `ssh-keygen -R <host>` is needed before the next `bin/hocho apply`. Both are printed as next steps.
+
 ### Prepare environment for hocho apply
 
 After the instance exists and its DNS record is live (`bin/launch` does both for EC2 hosts; records are managed under `dns/rubyci.org/`, see `dns/README.md`), bootstrap the host with the cloud image's default user:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,23 @@
 
 ## Usage
 
+### Launch
+
+`bin/launch` creates a host's EC2 instance through the EC2 API, so a new host needs no web console. The security group (`chkbuild`), instance profile (`chkbuild-uploader`), IMDSv2 requirement and gp3 root volume are the same for every host and are fixed in the script, which leaves the AMI id and the instance type as arguments. The subnet defaults to a default-for-az subnet of the security group's VPC, choosing an availability zone that offers the requested instance type, because the zones do not all offer the same ones. As with `bin/reboot` the region is fixed to `ap-northeast-1` and the AWS CLI is expected to be configured with credentials for the account holding the instances.
+
+```bash
+# resolve the AMI, subnet and Name tag, then dry-run the API call
+bin/launch -n fedora45.rubyci.org ami-0123456789abcdef0 c5a.large
+
+# launch, taking one of the idle Elastic IPs
+bin/launch --eip 52.69.117.212 fedora45.rubyci.org ami-0123456789abcdef0 c5a.large
+```
+
+`--eip new` allocates a new Elastic IP and `--eip <address|allocation id>` takes an existing unassociated one. Either way a `*.rubyci.org` host gets its A record written into `dns/rubyci.org/dnsconfig.js`, and committing that is what applies the zone. Without `--eip` the instance keeps the address its subnet assigns, which is lost on the next stop. The Name tag is `rubyci-<label>`; pass `--name` where that does not hold, as with `riscv.rubyci.org` running on `rubyci-riscv64`.
+
 ### Prepare environment for hocho apply
 
-After launching a VM and assigning the Elastic IP (DNS records are managed under `dns/rubyci.org/`, see `dns/README.md`), bootstrap the host with the cloud image's default user:
+After the instance exists and its DNS record is live (`bin/launch` does both for EC2 hosts; records are managed under `dns/rubyci.org/`, see `dns/README.md`), bootstrap the host with the cloud image's default user:
 
 ```bash
 bin/bootstrap -i ~/.ssh/aws-keypair.pem fedora@fedora44-arm.rubyci.org

--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ bin/eip-swap debian11.rubyci.org i-0123456789abcdef0
 
 The replacement answers on a different host key under the same name, so `ssh-keygen -R <host>` is needed before the next `bin/hocho apply`. Both are printed as next steps.
 
+### Register with rubyci.org
+
+rubyci.org does not discover servers from the S3 bucket, so a host stays invisible on the page until a `Server` row exists for it, and that row is the one step of adding a host that lives outside this repository. `bin/rubyci-server` posts it to the `servers` API, deriving the log uri from the nickname the host's crontab reports under. The `root` basic-auth password is read from the app's own `ROOT_PASSWORD` config var rather than copied into a second place, which is why posting goes through the heroku CLI.
+
+```bash
+# read the public server list and print what would be posted; no credentials needed
+bin/rubyci-server -n "Fedora 45 x86_64" fedora45
+
+# rehearse against the staging app
+op run --env-file ~/.config/credentials/heroku.env -- bin/rubyci-server --app staging-rubyci "Fedora 45 x86_64" fedora45
+
+# register
+op run --env-file ~/.config/credentials/heroku.env -- bin/rubyci-server "Fedora 45 x86_64" fedora45
+```
+
+The page is sorted by `ordinal`, a float. The default appends the host to the bottom, from where the servers page moves it up; `--ordinal` between two neighbours puts it next to its family straight away. `--eol` records the end of life shown for hosts that are on their way out.
+
 ### Prepare environment for hocho apply
 
 After the instance exists and its DNS record is live (`bin/launch` does both for EC2 hosts; records are managed under `dns/rubyci.org/`, see `dns/README.md`), bootstrap the host with the cloud image's default user:

--- a/bin/eip-swap
+++ b/bin/eip-swap
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Move a host's Elastic IP to a replacement instance, so an EOL host can be
+# rotated out without touching DNS.
+#
+# Usage: bin/eip-swap [-n] <host> <instance-id>
+#   -n  resolve both ends and dry-run the API call, do not reassociate
+#
+# The replacement is launched with `bin/launch` and no --eip, then bootstrapped
+# and applied on the temporary address its subnet assigns; this hands it the
+# host name afterwards. The A record under dns/rubyci.org/ never changes, so
+# nothing has to be committed and no zone push is involved.
+#
+# The old instance is left running but loses its public address entirely, so
+# stop or terminate it once the replacement is known good.
+#
+# The AWS CLI is expected to be configured with credentials for the account
+# holding the instances.
+
+require 'open3'
+require 'optparse'
+require 'resolv'
+
+REGION = 'ap-northeast-1'
+
+dry_run = false
+opt = OptionParser.new
+opt.banner = 'usage: bin/eip-swap [-n] <host> <instance-id>'
+opt.on('-n', 'dry-run the API call') { dry_run = true }
+args = opt.parse(ARGV)
+abort opt.banner unless args.size == 2
+host, instance = args
+
+def aws(*command)
+  out, err, status = Open3.capture3('aws', '--region', REGION, *command)
+  abort "aws #{command.first(2).join(' ')} failed: #{err.strip}" unless status.success?
+  out
+end
+
+# hosts.yml carries no instance id and the Name tag does not always follow the
+# host name, so reach the allocation through the address the host resolves to.
+address = begin
+  Resolv.getaddress(host)
+rescue Resolv::ResolvError => e
+  abort "cannot resolve #{host}: #{e.message}"
+end
+
+rows = aws('ec2', 'describe-addresses', '--filters', "Name=public-ip,Values=#{address}",
+           '--query', 'Addresses[].[AllocationId,InstanceId]', '--output', 'text').lines
+abort "#{address} (#{host}) is not an Elastic IP in this account" if rows.empty?
+allocation, current = rows.first.split
+
+if current == instance
+  puts "eip-swap: host=#{host} eip=#{address} instance=#{instance} status=unchanged"
+  exit
+end
+
+state, name = aws('ec2', 'describe-instances', '--instance-ids', instance,
+                  '--query', 'Reservations[0].Instances[0].[State.Name,Tags[?Key==`Name`].Value|[0]]',
+                  '--output', 'text').strip.split("\t", 2)
+abort "#{instance} is #{state}, not running" unless state == 'running'
+
+puts "eip-swap: host=#{host} eip=#{address} from=#{current} to=#{instance} (#{name})"
+
+associate = ['ec2', 'associate-address', '--allocation-id', allocation,
+             '--instance-id', instance, '--allow-reassociation']
+
+if dry_run
+  # A dry run always fails; DryRunOperation is what success looks like.
+  _out, err, = Open3.capture3('aws', '--region', REGION, *associate, '--dry-run')
+  abort "dry run failed: #{err.strip}" unless err.include?('DryRunOperation')
+  puts 'eip-swap: status=dry-run'
+  exit
+end
+
+aws(*associate)
+puts 'eip-swap: status=swapped'
+puts <<~NEXT
+  Next steps:
+    ssh-keygen -R #{host}
+    bin/hocho apply #{host}
+    stop or terminate #{current} once #{host} is known good
+NEXT

--- a/bin/launch
+++ b/bin/launch
@@ -1,0 +1,166 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Launch an EC2 instance for a new host through the EC2 API, so that a host can
+# be built without the web console.
+#
+# Usage: bin/launch [options] <host> <ami-id> <instance-type>
+#   -n              resolve everything and dry-run the API call, do not launch
+#   --key NAME      keypair injected at launch (default: $USER)
+#   --name TAG      Name tag (default: rubyci-<label> for a *.rubyci.org host)
+#   --subnet ID     subnet to launch in (default: see below)
+#   --size GB       root volume size (default: 40)
+#   --eip new|ADDR  allocate a new Elastic IP, or take an existing unassociated
+#                   one by address or allocation id
+#
+# The security group, instance profile, IMDS options and root volume type are
+# the same for every host here and are not configurable. The subnet defaults to
+# a default-for-az subnet of the security group's VPC, picking an availability
+# zone that offers the requested instance type.
+#
+# Without --eip the instance keeps the address its subnet assigns, which is lost
+# on the next stop; a permanent host wants --eip. With --eip on a *.rubyci.org
+# host the A record is written into dns/rubyci.org/dnsconfig.js, and committing
+# it is what applies it.
+#
+# The AWS CLI is expected to be configured with credentials for the account
+# holding the instances.
+
+require 'open3'
+require 'optparse'
+
+REGION = 'ap-northeast-1'
+SECURITY_GROUP = 'chkbuild'
+INSTANCE_PROFILE = 'chkbuild-uploader'
+DNS_CONFIG = 'dns/rubyci.org/dnsconfig.js'
+
+options = { key: ENV['USER'], size: 40 }
+opt = OptionParser.new
+opt.banner = 'usage: bin/launch [options] <host> <ami-id> <instance-type>'
+opt.on('-n', 'dry-run the API call') { options[:dry_run] = true }
+opt.on('--key NAME', 'keypair name') { |v| options[:key] = v }
+opt.on('--name TAG', 'Name tag') { |v| options[:name] = v }
+opt.on('--subnet ID', 'subnet id') { |v| options[:subnet] = v }
+opt.on('--size GB', Integer, 'root volume size in GB') { |v| options[:size] = v }
+opt.on('--eip ADDR', 'new, or an existing address / allocation id') { |v| options[:eip] = v }
+args = opt.parse(ARGV)
+abort opt.banner unless args.size == 3
+host, ami, type = args
+abort 'no keypair name: pass --key' if options[:key].to_s.empty?
+
+Dir.chdir(File.expand_path('..', __dir__))
+
+def aws(*command)
+  out, err, status = Open3.capture3('aws', '--region', REGION, *command)
+  abort "aws #{command.first(2).join(' ')} failed: #{err.strip}" unless status.success?
+  out
+end
+
+label = host.split('.').first
+# The Name tag follows the host name, but not always: riscv.rubyci.org runs on
+# `rubyci-riscv64`. --name covers a host whose tag cannot be derived.
+name = options[:name] || (host.end_with?('.rubyci.org') ? "rubyci-#{label}" : label)
+
+# Debian and FreeBSD images root on /dev/sda1 and the rest on /dev/xvda, so the
+# block device mapping that resizes the root volume has to follow the AMI.
+root_device, ami_name = aws('ec2', 'describe-images', '--image-ids', ami,
+                            '--query', 'Images[0].[RootDeviceName,Name]', '--output', 'text').split
+
+group_id, vpc = aws('ec2', 'describe-security-groups',
+                    '--filters', "Name=group-name,Values=#{SECURITY_GROUP}",
+                    '--query', 'SecurityGroups[0].[GroupId,VpcId]', '--output', 'text').split
+# The group exists in the account that holds the instances and nowhere else, so
+# a miss here means the AWS CLI is pointed at the wrong one.
+abort "no security group named #{SECURITY_GROUP}: wrong AWS account?" if vpc.nil?
+
+subnet = options[:subnet] || begin
+  # The default subnets of the VPC differ in which instance types they offer, so
+  # narrow them to the zones that have this one before picking.
+  zones = aws('ec2', 'describe-instance-type-offerings',
+              '--location-type', 'availability-zone',
+              '--filters', "Name=instance-type,Values=#{type}",
+              '--query', 'InstanceTypeOfferings[].Location', '--output', 'text').split
+  abort "#{type} is not offered in #{REGION}" if zones.empty?
+  subnets = aws('ec2', 'describe-subnets',
+                '--filters', "Name=vpc-id,Values=#{vpc}",
+                'Name=default-for-az,Values=true',
+                "Name=availability-zone,Values=#{zones.join(',')}",
+                '--query', 'Subnets[].[AvailabilityZone,SubnetId]', '--output', 'text')
+             .lines.map(&:split).sort
+  abort "no default subnet in #{vpc} offers #{type}" if subnets.empty?
+  subnets.first.last
+end
+
+run_instances = [
+  'ec2', 'run-instances',
+  '--image-id', ami,
+  '--instance-type', type,
+  '--key-name', options[:key],
+  '--subnet-id', subnet,
+  '--security-group-ids', group_id,
+  '--iam-instance-profile', "Name=#{INSTANCE_PROFILE}",
+  # A hop limit of 1 keeps the instance profile credentials from being read
+  # through the extra network hop a container on the host would add.
+  '--metadata-options', 'HttpTokens=required,HttpPutResponseHopLimit=1',
+  '--block-device-mappings',
+  "DeviceName=#{root_device},Ebs={VolumeSize=#{options[:size]},VolumeType=gp3,DeleteOnTermination=true}",
+  '--tag-specifications', "ResourceType=instance,Tags=[{Key=Name,Value=#{name}}]",
+]
+
+puts "launch: host=#{host} name=#{name} ami=#{ami} (#{ami_name}) type=#{type} " \
+     "subnet=#{subnet} key=#{options[:key]} root=#{options[:size]}GB"
+
+if options[:dry_run]
+  # A dry run always fails; DryRunOperation is what success looks like.
+  _out, err, = Open3.capture3('aws', '--region', REGION, *run_instances, '--dry-run')
+  abort "dry run failed: #{err.strip}" unless err.include?('DryRunOperation')
+  puts 'launch: status=dry-run'
+  exit
+end
+
+instance = aws(*run_instances, '--query', 'Instances[0].InstanceId', '--output', 'text').strip
+puts "launch: instance=#{instance} status=pending"
+aws('ec2', 'wait', 'instance-running', '--instance-ids', instance)
+
+if options[:eip]
+  allocation, address =
+    if options[:eip] == 'new'
+      aws('ec2', 'allocate-address', '--domain', 'vpc',
+          '--tag-specifications', "ResourceType=elastic-ip,Tags=[{Key=Name,Value=#{name}}]",
+          '--query', '[AllocationId,PublicIp]', '--output', 'text').split
+    else
+      filter = options[:eip].start_with?('eipalloc-') ? 'allocation-id' : 'public-ip'
+      rows = aws('ec2', 'describe-addresses', '--filters', "Name=#{filter},Values=#{options[:eip]}",
+                 '--query', 'Addresses[].[AllocationId,PublicIp,AssociationId]', '--output', 'text').lines
+      abort "no such Elastic IP: #{options[:eip]}" if rows.empty?
+      alloc, ip, association = rows.first.split
+      abort "#{ip} is already associated (#{association})" unless association == 'None'
+      [alloc, ip]
+    end
+  aws('ec2', 'associate-address', '--instance-id', instance, '--allocation-id', allocation)
+  puts "launch: eip=#{address} allocation=#{allocation}"
+else
+  address = aws('ec2', 'describe-instances', '--instance-ids', instance,
+                '--query', 'Reservations[0].Instances[0].PublicIpAddress', '--output', 'text').strip
+  puts "launch: address=#{address} (temporary, lost on stop)"
+end
+
+steps = []
+if options[:eip] && host.end_with?('.rubyci.org')
+  config = File.read(DNS_CONFIG).lines
+  if config.any? { |line| line.start_with?(%[\tA("#{label}", ]) }
+    puts "launch: dns=skipped (#{label} is already in #{DNS_CONFIG})"
+  else
+    # The A records are not in any order, so append to the end of the block.
+    config.insert(config.rindex { |line| line.start_with?("\tA(") } + 1,
+                  %[\tA("#{label}", "#{address}"),\n])
+    File.write(DNS_CONFIG, config.join)
+    puts "launch: dns=#{DNS_CONFIG}"
+    steps << "commit #{DNS_CONFIG} and merge it; the dns workflow pushes the zone"
+  end
+end
+steps << "add #{host} to hosts.yml"
+steps << "bin/bootstrap -i <keypair.pem> <cloud image user>@#{host}"
+steps << "bin/hocho apply #{host}"
+
+puts 'Next steps:'
+steps.each { |step| puts "  #{step}" }

--- a/bin/rubyci-server
+++ b/bin/rubyci-server
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Register a chkbuild host with rubyci.org, the one step of adding a host that
+# lives outside this repository.
+#
+# Usage: bin/rubyci-server [-n] [--app APP] [--ordinal N] [--eol DATE] <name> <nickname>
+#   -n           print the request and exit, do not post
+#   --app APP    Heroku app to register with (default: rubyci)
+#   --ordinal N  display order (default: after the last server)
+#   --eol DATE   end of life, YYYY-MM-DD
+#
+# <nickname> is what the host's crontab sets RUBYCI_NICKNAME to and the S3
+# prefix its logs land under; the uri is derived from it. rubyci.org does not
+# discover servers from the bucket, so a host stays invisible until this row
+# exists. The ordinal is a float and the page is sorted by it, so a value
+# between two neighbours drops the new host next to its family, while the
+# default appends it to the bottom to be moved up from the servers page.
+#
+# The `root` basic-auth password is read from the app's own ROOT_PASSWORD config
+# var instead of being copied into a second place, so posting needs an
+# authenticated heroku CLI:
+#
+#   op run --env-file ~/.config/credentials/heroku.env -- bin/rubyci-server ...
+#
+# Rehearse against the staging app with --app staging-rubyci. A dry run reads
+# nothing but the public server list and needs no credentials at all.
+
+require 'json'
+require 'net/http'
+require 'open3'
+require 'optparse'
+
+LOG_BUCKET_URL = 'https://rubyci.s3.amazonaws.com'
+
+options = { app: 'rubyci' }
+opt = OptionParser.new
+opt.banner = 'usage: bin/rubyci-server [-n] [--app APP] [--ordinal N] [--eol DATE] <name> <nickname>'
+opt.on('-n', 'print the request and exit') { options[:dry_run] = true }
+opt.on('--app APP', 'Heroku app to register with') { |v| options[:app] = v }
+opt.on('--ordinal N', Float, 'display order') { |v| options[:ordinal] = v }
+opt.on('--eol DATE', 'end of life, YYYY-MM-DD') { |v| options[:eol] = v }
+args = opt.parse(ARGV)
+abort opt.banner unless args.size == 2
+name, nickname = args
+
+# Only the production app has a custom domain.
+base = URI.parse(options[:app] == 'rubyci' ? 'https://rubyci.org' : "https://#{options[:app]}.herokuapp.com")
+
+servers = JSON.parse(Net::HTTP.get(URI.join(base, '/servers.json')))
+abort "#{nickname} is already registered on #{options[:app]}" if
+  servers.any? { |server| server['uri'].to_s.include?("/#{nickname}") }
+
+server = {
+  name: name,
+  uri: "#{LOG_BUCKET_URL}/#{nickname}/",
+  # Going past the last one leaves the ordinal of every existing row alone.
+  ordinal: options[:ordinal] || servers.map { |s| s['ordinal'].to_f }.max + 1,
+}
+server[:eol_date] = options[:eol] if options[:eol]
+
+puts "rubyci-server: app=#{options[:app]} #{server.map { |k, v| "#{k}=#{v}" }.join(' ')}"
+if options[:dry_run]
+  puts 'rubyci-server: status=dry-run'
+  exit
+end
+
+out, err, status = Open3.capture3('heroku', 'config:get', 'ROOT_PASSWORD', '-a', options[:app])
+unless status.success?
+  abort "cannot read ROOT_PASSWORD from #{options[:app]}, " \
+        "run under `op run --env-file ~/.config/credentials/heroku.env`: #{err.strip}"
+end
+password = out.strip
+abort "ROOT_PASSWORD is not set on #{options[:app]}" if password.empty?
+
+endpoint = URI.join(base, '/servers.json')
+request = Net::HTTP::Post.new(endpoint, 'Content-Type' => 'application/json')
+request.basic_auth('root', password)
+request.body = JSON.dump(server: server)
+response = Net::HTTP.start(endpoint.host, endpoint.port, use_ssl: endpoint.scheme == 'https') do |http|
+  http.request(request)
+end
+
+case response
+when Net::HTTPCreated
+  puts "rubyci-server: id=#{JSON.parse(response.body)['id']} status=created"
+when Net::HTTPUnauthorized
+  abort "rubyci-server: #{options[:app]} rejected the root password"
+else
+  abort "rubyci-server: #{response.code} #{response.message}: #{response.body.to_s[0, 500]}"
+end


### PR DESCRIPTION
Adding a host meant clicking through the EC2 console, and the entry on rubyci.org had to be created by hand afterwards. These three commands cover that path.

`bin/launch` creates the instance. The security group, instance profile, IMDSv2 options and gp3 root volume are the same for every host and stay in the script, so only the AMI id and the instance type are arguments. The subnet is resolved from the requested instance type because the default subnets of the VPC do not all offer the same ones, and the root device name comes from the AMI because Debian and FreeBSD images root on `/dev/sda1` while the rest use `/dev/xvda`.

`bin/eip-swap` hands a host name to a replacement instance, which is what keeps an EOL rotation out of DNS.

`bin/rubyci-server` posts the `Server` row that rubyci.org needs, since it does not discover hosts from the bucket. The `root` password is read from the app's own `ROOT_PASSWORD` config var rather than copied into a second place.

```bash
bin/launch --eip 203.0.113.10 fedora45.rubyci.org ami-0123456789abcdef0 c5a.large
bin/bootstrap -i ~/.ssh/aws-keypair.pem fedora@fedora45.rubyci.org
bin/hocho apply fedora45.rubyci.org
op run --env-file ~/.config/credentials/heroku.env -- bin/rubyci-server "Fedora 45 x86_64" fedora45
```

The `servers` API path was rehearsed against `staging-rubyci` and the rows removed afterwards. The EC2 side is covered by dry runs, so no instance was launched.

Generated with [Claude Code](https://claude.com/claude-code)
