### PR TITLE
Add amazon2027.rubyci.org on the Amazon Linux 2027 preview

### DIFF
--- a/dns/rubyci.org/dnsconfig.js
+++ b/dns/rubyci.org/dnsconfig.js
@@ -27,6 +27,7 @@ D("rubyci.org", REG_NONE,
 	A("ubuntu2404", "18.180.242.9"),
 	A("ubuntu-arm", "18.178.229.119"),
 	A("ubuntu", "35.72.236.42"),
+	A("amazon2027", "52.69.117.212"),
 	// Cloudflare flattens this apex CNAME; dnscontrol expresses it as ALIAS.
 	ALIAS("@", "rubyci.org.herokudns.com."),
 	CNAME("www", "www.rubyci.org.herokudns.com."),

--- a/hosts.yml
+++ b/hosts.yml
@@ -180,6 +180,13 @@ amazon2023.rubyci.org:
     run_list:
       - recipes/default.rb
 
+amazon2027.rubyci.org:
+  properties:
+    nopasswd_sudo: true
+    compress: false
+    run_list:
+      - recipes/default.rb
+
 debian12.rubyci.org:
   properties:
     nopasswd_sudo: true


### PR DESCRIPTION
The instance is already running as `i-051d392f776b3975e` (c7a.large) on 52.69.117.212, taken from the idle Elastic IP pool. Merging this pushes the A record so the host can be bootstrapped and applied.

Amazon Linux 2027 is still a preview. The AMI receives no updates and its support ends on 2026-12-31, so I expect to rebuild the host at GA. What I am after is the coverage of GCC 16, which is the compiler the next Amazon Linux will build ruby with.

`ID=amzn` and `VERSION_ID=2027` keep the `amzn` branch in `bin/bootstrap-remote.sh` and the `amazon` platform branches in the recipes working unchanged. The one known package difference is `zlib-devel`, now a virtual provide of `zlib-ng-compat-devel`. Installing still succeeds and only the `rpm -q` idempotency check misses, so I left the rbenv plugin alone for now.

Generated with [Claude Code](https://claude.com/claude-code)