### PR TITLE
Enable crond through systemd on the amazon platform

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -81,6 +81,9 @@ when 'fedora', 'amazon'
   package 'cronie'
   package 'cronie-anacron'
   service 'crond' do
+    # specinfra maps the amazon platform to the pre-systemd RedHat commands,
+    # and Amazon Linux 2027 no longer ships the chkconfig they call.
+    provider :systemd
     action [:enable, :start]
   end
   package 'patch'


### PR DESCRIPTION
The `amazon2027` apply died on `service[crond]`. specinfra resolves the amazon platform to the pre-systemd RedHat command set, so the service resource shells out to `chkconfig`, and Amazon Linux 2027 no longer ships it. Amazon Linux 2023 still does, which is why this held until now. Pinning the provider to `systemd` fixes 2027 and is what 2 and 2023 want anyway.

Applied on `amazon2027.rubyci.org`, where `crond` is now enabled and active and a repeat apply reports no change.

Generated with [Claude Code](https://claude.com/claude-code)
