### PR TITLE
Add instructions for installing more OpenBSD packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ sudo qemu-system-x86_64 \
 Important information during OpenBSD installation. If an answer
 isn't listed here, use the default:
 
-* System hostname: `rubyci-openbsd`
+* System hostname: `openbsd`
 * Password: randomly generate a secure one and store it
 * Do you expect to run the X Window System? `no`
 * Which speed should com0 use? `115200`
@@ -169,7 +169,7 @@ Then exit the root shell.
 Install the necessary packages needed for CI:
 
 ```sh
-doas pkg_add rsync-- bash sudo-- git
+doas pkg_add rsync-- bash sudo-- git gmake autoconf%2.69 automake%1.16
 ```
 
 Then configure `sudo`


### PR DESCRIPTION
These are needed for chkbuild to work.

Additionally, use openbsd as the system hostname, as I don't think the other RubyCI machines use a rubyci hostname prefix.