### PR TITLE
Add the blade-mcp Heroku app and its vault reader

### DIFF
--- a/heroku/.terraform.lock.hcl
+++ b/heroku/.terraform.lock.hcl
@@ -1,6 +1,30 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.64.0"
+  constraints = "~> 6.57"
+  hashes = [
+    "h1:wXARLY+IeQ7ufYxCLTPCwToWGMRvOpiOTfJS97iwUzI=",
+    "zh:07172315d67bc9781240272759cdfc7bd32b7e72384a56862c2c1da3cca99a81",
+    "zh:154ce7d2659de9a59ddfe96d7cab41a9ddc2cb267a7d4bcdf4e737ff2ffdec06",
+    "zh:17324d4335a7a7ac01cc23eded530775606680ff53b47cb74a3cb95d1121f836",
+    "zh:307ab92324ec5a61b124881ab8cac1d9e316f4527dfd0e1b59794c229407eb4e",
+    "zh:31e25f1903661332e36a95283042dd3ec50b47c186db00663fbd976a11e6a6b2",
+    "zh:3311d9f3bd12a24886027dbe73859dcd1e67bd0e3046227a338cf2c7ca04d18e",
+    "zh:37916156a3aac3b29be3acebd15d53145ea4ab5d4aaa825eaebe75481fa00500",
+    "zh:4158cb8c38b3ac6aa98eb15935ec6bd7c30838d85d2b00acc9812df8382ae908",
+    "zh:5bfb9499c66d9db5b34dc5c60f426a1ab1baa5457ce2aefebca826a9c3f92fb0",
+    "zh:6eb29ead5a4aca3b1f35812e7e8c75419180e1928e479b458f206861277736db",
+    "zh:7a82b6dd0c0cdef8045a4adfbddd36acb86b6b23fcbed8e189c2d71f7dc4a502",
+    "zh:9556bd792032c3f7e73ea4dd08cec88dc1327f5a4a57d79c30ba844ae2b9a3c0",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c5234180464cb800c83a41f57462742b802c150ad7d4417626fcd9cb511c01d2",
+    "zh:cd776b83b1f7b36635957350afe7ce28ba4e4ea3a5e2deb00d13dbd3b35d9d40",
+    "zh:fb583a7b791c6f915b86573d04f05ddbf7f1a5e4120c5d8a7450a3086c1225c4",
+  ]
+}
+
 provider "registry.terraform.io/heroku/heroku" {
   version     = "5.4.0"
   constraints = "~> 5.4"

--- a/heroku/blade_mcp_ruby_lang.tf
+++ b/heroku/blade_mcp_ruby_lang.tf
@@ -10,6 +10,18 @@ resource "heroku_app" "blade_mcp_ruby_lang" {
   }
 }
 
+import {
+  to = heroku_formation.blade_mcp_ruby_lang_web
+  id = "blade-mcp-ruby-lang:web"
+}
+
+resource "heroku_formation" "blade_mcp_ruby_lang_web" {
+  app_id   = heroku_app.blade_mcp_ruby_lang.id
+  type     = "web"
+  quantity = 1
+  size     = "basic"
+}
+
 resource "heroku_addon" "blade_mcp_ruby_lang_postgresql" {
   app_id = heroku_app.blade_mcp_ruby_lang.id
   plan   = "heroku-postgresql:standard-0"

--- a/heroku/blade_mcp_ruby_lang.tf
+++ b/heroku/blade_mcp_ruby_lang.tf
@@ -1,0 +1,40 @@
+resource "heroku_app" "blade_mcp_ruby_lang" {
+  name   = "blade-mcp-ruby-lang"
+  region = "us"
+  stack  = "heroku-26"
+
+  buildpacks = ["heroku/ruby"]
+
+  organization {
+    name = "ruby-core"
+  }
+}
+
+resource "heroku_addon" "blade_mcp_ruby_lang_postgresql" {
+  app_id = heroku_app.blade_mcp_ruby_lang.id
+  plan   = "heroku-postgresql:standard-0"
+}
+
+resource "heroku_addon" "blade_mcp_ruby_lang_scheduler" {
+  app_id = heroku_app.blade_mcp_ruby_lang.id
+  plan   = "scheduler:standard"
+}
+
+# The standard plan serves every model, picked per request, so one add-on
+# backs both names the app reads.
+resource "heroku_addon" "blade_mcp_ruby_lang_inference" {
+  app_id = heroku_app.blade_mcp_ruby_lang.id
+  plan   = "heroku-inference:standard"
+}
+
+resource "heroku_addon_attachment" "blade_mcp_ruby_lang_embedding" {
+  app_id   = heroku_app.blade_mcp_ruby_lang.id
+  addon_id = heroku_addon.blade_mcp_ruby_lang_inference.id
+  name     = "EMBEDDING"
+}
+
+resource "heroku_addon_attachment" "blade_mcp_ruby_lang_rerank" {
+  app_id   = heroku_app.blade_mcp_ruby_lang.id
+  addon_id = heroku_addon.blade_mcp_ruby_lang_inference.id
+  name     = "RERANK"
+}

--- a/heroku/blade_ruby_lang.tf
+++ b/heroku/blade_ruby_lang.tf
@@ -16,6 +16,10 @@ resource "heroku_formation" "blade_ruby_lang_web" {
   type     = "web"
   quantity = 7
   size     = "performance-m"
+
+  lifecycle {
+    ignore_changes = [quantity]
+  }
 }
 
 resource "heroku_addon" "blade_ruby_lang_postgresql" {

--- a/heroku/blade_ruby_lang.tf
+++ b/heroku/blade_ruby_lang.tf
@@ -14,7 +14,7 @@ resource "heroku_app" "blade_ruby_lang" {
 resource "heroku_formation" "blade_ruby_lang_web" {
   app_id   = heroku_app.blade_ruby_lang.id
   type     = "web"
-  quantity = 10
+  quantity = 7
   size     = "performance-m"
 }
 

--- a/heroku/iam.tf
+++ b/heroku/iam.tf
@@ -1,0 +1,26 @@
+# The access key is issued with `aws iam create-access-key` and set on the app
+# by hand, because Terraform would keep the secret in plain text in the state.
+resource "aws_iam_user" "blade_mcp" {
+  name = "blade-mcp"
+}
+
+resource "aws_iam_user_policy" "blade_mcp" {
+  name = "blade-data-vault-read"
+  user = aws_iam_user.blade_mcp.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = ["arn:aws:s3:::blade-data-vault"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = ["arn:aws:s3:::blade-data-vault/*"]
+      },
+    ]
+  })
+}

--- a/heroku/versions.tf
+++ b/heroku/versions.tf
@@ -13,7 +13,16 @@ terraform {
       source  = "heroku/heroku"
       version = "~> 5.4"
     }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.57"
+    }
   }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
 }
 
 provider "heroku" {


### PR DESCRIPTION
blade-mcp (`ruby/blade-mcp`) serves the mailing list archive over MCP, and it builds its index from the raw messages in the private `blade-data-vault` bucket. This adds the `blade-mcp-ruby-lang` app with Postgres, Scheduler and a `heroku-inference:standard` add-on attached as `EMBEDDING` and `RERANK`, plus an IAM user that can only read that bucket. The name `blade-mcp` was already taken on Heroku.

The access key is not managed here because Terraform would keep the secret in the state. Creating the app needed a token with the global scope, since the `write-protected` one is refused on `POST /teams/apps`. Everything is already applied, and the web formation Heroku created on the first deploy is imported.

I also set `ignore_changes` on the `blade-ruby-lang` web quantity. The app autoscales, so every plan showed a diff and an apply would have reset the count.

Generated with [Claude Code](https://claude.com/claude-code)
